### PR TITLE
[BUGFIX] Fix gitignore last-rule-wins semantics for file exclusion

### DIFF
--- a/internal/rsync/sync.go
+++ b/internal/rsync/sync.go
@@ -212,26 +212,27 @@ func (s *Scanner) Scan() ([]FileInfo, error) {
 func (s *Scanner) shouldInclude(relPath string, isDir bool) bool {
 	pathParts := strings.Split(relPath, "/")
 
-	// Check if any exclude pattern matches
+	// Last matching rule wins (standard gitignore semantics)
 	excluded := false
 	for _, pattern := range s.excludes {
 		result := pattern.Match(pathParts, isDir)
-		if result == gitignore.Exclude {
+		switch result {
+		case gitignore.Exclude:
 			excluded = true
-			break
+		case gitignore.Include:
+			excluded = false
 		}
 	}
 
-	// If excluded, check if any include pattern overrides the exclusion
+	// Config-level include patterns act as a final override
 	if excluded {
 		for _, pattern := range s.includes {
 			result := pattern.Match(pathParts, isDir)
-			// Include result (negation pattern) overrides exclusion
 			if result == gitignore.Include {
 				return true
 			}
 		}
-		return false // Excluded and no override
+		return false
 	}
 
 	// Not excluded - include by default

--- a/internal/rsync/sync_test.go
+++ b/internal/rsync/sync_test.go
@@ -1,0 +1,89 @@
+package rsync
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+func makeScanner(excludePatterns, includePatterns []string) *Scanner {
+	s := &Scanner{gitignoreCache: make(map[string][]gitignore.Pattern)}
+	for _, p := range excludePatterns {
+		s.excludes = append(s.excludes, gitignore.ParsePattern(p, nil))
+	}
+	for _, p := range includePatterns {
+		neg := p
+		if len(p) == 0 || p[0] != '!' {
+			neg = "!" + p
+		}
+		s.includes = append(s.includes, gitignore.ParsePattern(neg, nil))
+	}
+	return s
+}
+
+func TestShouldInclude(t *testing.T) {
+	tests := []struct {
+		name     string
+		excludes []string
+		includes []string
+		path     string
+		isDir    bool
+		want     bool
+	}{
+		{
+			name:    "no patterns includes everything",
+			path:    "src/main.go",
+			want:    true,
+		},
+		{
+			name:     "excluded file is skipped",
+			excludes: []string{"*.log"},
+			path:     "app.log",
+			want:     false,
+		},
+		{
+			name:     "non-matching exclude keeps file",
+			excludes: []string{"*.log"},
+			path:     "src/main.go",
+			want:     true,
+		},
+		{
+			name:     "negation after exclude re-includes file",
+			excludes: []string{"vendor", "!vendor/acme"},
+			path:     "vendor/acme",
+			isDir:    true,
+			want:     true,
+		},
+		{
+			name:     "later exclude overrides earlier negation",
+			excludes: []string{"!vendor/acme", "vendor"},
+			path:     "vendor/acme",
+			isDir:    true,
+			want:     false,
+		},
+		{
+			name:     "config include overrides exclude",
+			excludes: []string{"*.env"},
+			includes: []string{".env.example"},
+			path:     ".env.example",
+			want:     true,
+		},
+		{
+			name:     "config include does not affect non-excluded file",
+			excludes: []string{"*.log"},
+			includes: []string{"keep.txt"},
+			path:     "keep.txt",
+			want:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := makeScanner(tc.excludes, tc.includes)
+			got := s.shouldInclude(tc.path, tc.isDir)
+			if got != tc.want {
+				t.Errorf("shouldInclude(%q, dir=%v) = %v, want %v", tc.path, tc.isDir, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Gitignore applies a "last matching rule wins" strategy, meaning a negation pattern (!) later in the file can re-include a previously excluded path. The previous implementation broke out of the exclude loop on the first match, making it impossible for later rules to override earlier ones.

This fix iterates all exclude patterns and lets each one update the excluded state, so the final result reflects the last matching rule, consistent with standard gitignore behavior.