### PR TITLE
[FEATURE] Add ProxyCommand to work around network extension blocking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/kevinburke/ssh_config v1.6.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.52.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -41,7 +42,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
-	github.com/kevinburke/ssh_config v1.6.0 // indirect
+
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/makeworld-the-better-one/dither/v2 v2.4.0 // indirect

--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -25,6 +25,7 @@ type ClientOptions struct {
 	SSHMultiplexing    bool
 	KnownHostsFile     string
 	HostKeyFingerprint string
+	ProxyCommand       string // optional: shell command to establish TCP transport (e.g. "/usr/bin/nc %h %p")
 }
 
 // Client represents an SSH client connection
@@ -36,6 +37,7 @@ type Client struct {
 	user               string
 	options            map[string]string
 	multiplexing       bool
+	proxyCommand       string
 	keepaliveInterval  time.Duration
 	keepaliveCountMax  int
 	keepaliveStopChan  chan struct{}
@@ -53,6 +55,14 @@ func NewClient(host, user, keyPath string) (*Client, error) {
 
 // NewClientWithOptions creates a new SSH client with full options
 func NewClientWithOptions(opts ClientOptions) (*Client, error) {
+	// Extract ProxyCommand from ssh_options if set there (takes precedence over SSH config)
+	if opts.ProxyCommand == "" && opts.SSHOptions != nil {
+		opts.ProxyCommand = opts.SSHOptions["ProxyCommand"]
+	}
+
+	// Apply ~/.ssh/config as defaults; .shippy.yaml values already set take precedence.
+	applySSHConfig(&opts)
+
 	// Set default port if not specified
 	if opts.Port == 0 {
 		opts.Port = DefaultSSHPort
@@ -129,6 +139,9 @@ func NewClientWithOptions(opts ClientOptions) (*Client, error) {
 	// Print SSH connection information
 	fmt.Fprintf(os.Stderr, "  SSH connection details:\n")
 	fmt.Fprintf(os.Stderr, "  • Target: %s@%s:%d\n", opts.User, opts.Host, opts.Port)
+	if opts.ProxyCommand != "" {
+		fmt.Fprintf(os.Stderr, "  • ProxyCommand: %s\n", opts.ProxyCommand)
+	}
 	fmt.Fprintf(os.Stderr, "  • SSH key: %s\n", keyPath)
 
 	// Create host key callback with proper verification
@@ -193,6 +206,7 @@ func NewClientWithOptions(opts ClientOptions) (*Client, error) {
 		user:              opts.User,
 		options:           opts.SSHOptions,
 		multiplexing:      opts.SSHMultiplexing,
+		proxyCommand:      opts.ProxyCommand,
 		keepaliveInterval: keepaliveInterval,
 		keepaliveCountMax: keepaliveCountMax,
 	}, nil
@@ -200,20 +214,34 @@ func NewClientWithOptions(opts ClientOptions) (*Client, error) {
 
 // Connect establishes the SSH connection
 func (c *Client) Connect() error {
-	// Build address with port
 	addr := fmt.Sprintf("%s:%d", c.host, c.port)
 
-	client, err := ssh.Dial("tcp", addr, c.config)
-	if err != nil {
-		return errors.SSHError(fmt.Sprintf("connecting to %s@%s", c.user, addr), err)
+	var client *ssh.Client
+
+	if c.proxyCommand != "" {
+		// ProxyCommand: let a trusted system binary own the TCP socket.
+		// The SSH handshake runs over the subprocess's stdio so network security
+		// agents (e.g. corporate endpoint protection) see a trusted binary
+		// making the connection rather than the Go runtime's direct syscalls.
+		conn, err := dialProxy(c.proxyCommand, c.host, c.port)
+		if err != nil {
+			return errors.SSHError(fmt.Sprintf("connecting to %s@%s via ProxyCommand", c.user, addr), err)
+		}
+		sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, c.config)
+		if err != nil {
+			_ = conn.Close()
+			return errors.SSHError(fmt.Sprintf("SSH handshake with %s@%s", c.user, addr), err)
+		}
+		client = ssh.NewClient(sshConn, chans, reqs)
+	} else {
+		var err error
+		client, err = ssh.Dial("tcp", addr, c.config)
+		if err != nil {
+			return errors.SSHError(fmt.Sprintf("connecting to %s@%s", c.user, addr), err)
+		}
 	}
 
 	c.client = client
-
-	// When multiplexing is enabled, the underlying TCP connection is reused
-	// for all sessions (NewSession calls). The golang.org/x/crypto/ssh library
-	// handles this automatically - each session multiplexes over the same connection.
-	// No additional configuration needed beyond keeping the client alive.
 
 	// Start keepalive goroutine if configured
 	if c.keepaliveInterval > 0 {

--- a/internal/ssh/proxyconn.go
+++ b/internal/ssh/proxyconn.go
@@ -1,0 +1,88 @@
+package ssh
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// proxyConn wraps a ProxyCommand subprocess as a net.Conn.
+// The subprocess establishes the TCP transport; the SSH handshake runs over
+// its stdio. This lets a trusted system binary (e.g. /usr/bin/nc) own the
+// TCP connection when a network security agent blocks direct Go connections.
+type proxyConn struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	remote string
+}
+
+func (c *proxyConn) Read(b []byte) (int, error)  { return c.stdout.Read(b) }
+func (c *proxyConn) Write(b []byte) (int, error) { return c.stdin.Write(b) }
+
+func (c *proxyConn) Close() error {
+	err1 := c.stdin.Close()
+	err2 := c.stdout.Close()
+	_ = c.cmd.Wait() // exit status of the proxy process is not meaningful on close
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}
+
+func (c *proxyConn) LocalAddr() net.Addr                      { return &pipeAddr{} }
+func (c *proxyConn) RemoteAddr() net.Addr                     { return &pipeAddr{c.remote} }
+func (c *proxyConn) SetDeadline(_ time.Time) error            { return nil }
+func (c *proxyConn) SetReadDeadline(_ time.Time) error        { return nil }
+func (c *proxyConn) SetWriteDeadline(_ time.Time) error       { return nil }
+
+type pipeAddr struct{ s string }
+
+func (a pipeAddr) Network() string { return "pipe" }
+func (a pipeAddr) String() string  { return a.s }
+
+// expandProxyTokens replaces OpenSSH-style tokens in a ProxyCommand string.
+func expandProxyTokens(command, host string, port int) string {
+	r := strings.NewReplacer(
+		"%%", "%",
+		"%h", host,
+		"%p", fmt.Sprintf("%d", port),
+	)
+	return r.Replace(command)
+}
+
+// dialProxy runs command via the shell and returns a net.Conn backed by its stdio.
+// command may contain %h/%p tokens (expanded to host/port) and shell syntax.
+func dialProxy(command, host string, port int) (net.Conn, error) {
+	expanded := expandProxyTokens(command, host, port)
+
+	// Run through sh so quoted args and shell constructs work, matching OpenSSH behaviour.
+	// #nosec G204 -- ProxyCommand is from user-controlled config (~/.ssh/config or .shippy.yaml)
+	cmd := exec.Command("sh", "-c", expanded)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("ProxyCommand stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("ProxyCommand stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, fmt.Errorf("ProxyCommand start %q: %w", expanded, err)
+	}
+
+	return &proxyConn{
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: stdout,
+		remote: fmt.Sprintf("%s:%d", host, port),
+	}, nil
+}

--- a/internal/ssh/proxyconn_test.go
+++ b/internal/ssh/proxyconn_test.go
@@ -1,0 +1,143 @@
+package ssh
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExpandProxyTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		host     string
+		port     int
+		expected string
+	}{
+		{
+			name:     "nc with host and port",
+			command:  "/usr/bin/nc %h %p",
+			host:     "sparkles.lan",
+			port:     22,
+			expected: "/usr/bin/nc sparkles.lan 22",
+		},
+		{
+			name:     "nc with IP and custom port",
+			command:  "/usr/bin/nc %h %p",
+			host:     "192.168.1.218",
+			port:     2222,
+			expected: "/usr/bin/nc 192.168.1.218 2222",
+		},
+		{
+			name:     "ssh ProxyJump style",
+			command:  "ssh -W %h:%p jump.host",
+			host:     "internal.host",
+			port:     22,
+			expected: "ssh -W internal.host:22 jump.host",
+		},
+		{
+			name:     "percent escape",
+			command:  "echo %%done",
+			host:     "host",
+			port:     22,
+			expected: "echo %done",
+		},
+		{
+			name:     "repeated tokens",
+			command:  "nc %h %p # connecting to %h",
+			host:     "myhost",
+			port:     22,
+			expected: "nc myhost 22 # connecting to myhost",
+		},
+		{
+			name:     "no tokens",
+			command:  "/usr/bin/nc myhost 22",
+			host:     "ignored",
+			port:     0,
+			expected: "/usr/bin/nc myhost 22",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandProxyTokens(tt.command, tt.host, tt.port)
+			if got != tt.expected {
+				t.Errorf("expandProxyTokens(%q, %q, %d) = %q, want %q",
+					tt.command, tt.host, tt.port, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDialProxyReadsOutput(t *testing.T) {
+	// echo outputs a fixed string immediately, no stdin needed.
+	conn, err := dialProxy("echo SSH-2.0-test", "testhost", 22)
+	if err != nil {
+		t.Fatalf("dialProxy: %v", err)
+	}
+	defer conn.Close()
+
+	buf := make([]byte, 64)
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got := strings.TrimSpace(string(buf[:n])); got != "SSH-2.0-test" {
+		t.Errorf("Read = %q, want %q", got, "SSH-2.0-test")
+	}
+}
+
+func TestDialProxyWriteRead(t *testing.T) {
+	// cat echoes stdin back to stdout; closing stdin flushes the output.
+	conn, err := dialProxy("cat", "testhost", 22)
+	if err != nil {
+		t.Fatalf("dialProxy: %v", err)
+	}
+
+	if _, err := conn.Write([]byte("hello")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	// Close stdin so cat flushes and exits.
+	conn.(*proxyConn).stdin.Close()
+
+	buf := make([]byte, 64)
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	n, _ := conn.Read(buf)
+	if got := string(buf[:n]); got != "hello" {
+		t.Errorf("Read = %q, want %q", got, "hello")
+	}
+	conn.Close()
+}
+
+func TestDialProxyAddrs(t *testing.T) {
+	conn, err := dialProxy("cat", "myhost", 2222)
+	if err != nil {
+		t.Fatalf("dialProxy: %v", err)
+	}
+	defer conn.Close()
+
+	if got := conn.RemoteAddr().String(); got != "myhost:2222" {
+		t.Errorf("RemoteAddr = %q, want %q", got, "myhost:2222")
+	}
+	if got := conn.RemoteAddr().Network(); got != "pipe" {
+		t.Errorf("RemoteAddr.Network = %q, want %q", got, "pipe")
+	}
+}
+
+func TestDialProxyTokensExpanded(t *testing.T) {
+	// Verify tokens are expanded before the command runs.
+	// printf %s echoes its argument without a trailing newline.
+	conn, err := dialProxy("printf '%s' %h:%p", "myhost", 22)
+	if err != nil {
+		t.Fatalf("dialProxy: %v", err)
+	}
+	defer conn.Close()
+
+	buf := make([]byte, 64)
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	n, _ := conn.Read(buf)
+	if got := string(buf[:n]); got != "myhost:22" {
+		t.Errorf("command output = %q, want %q", got, "myhost:22")
+	}
+}

--- a/internal/ssh/sshconfig.go
+++ b/internal/ssh/sshconfig.go
@@ -1,0 +1,46 @@
+package ssh
+
+import (
+	"strconv"
+
+	sshconfig "github.com/kevinburke/ssh_config"
+)
+
+// applySSHConfig reads ~/.ssh/config and fills in missing ClientOptions fields.
+// Values already set in .shippy.yaml always take precedence.
+func applySSHConfig(opts *ClientOptions) {
+	applyConfig(opts, sshconfig.Get)
+}
+
+// applyConfig fills in missing ClientOptions fields using the provided getter.
+// Extracted for testability; production callers pass sshconfig.Get.
+func applyConfig(opts *ClientOptions, get func(alias, key string) string) {
+	alias := opts.Host
+
+	if opts.ProxyCommand == "" {
+		if cmd := get(alias, "ProxyCommand"); cmd != "" {
+			opts.ProxyCommand = cmd
+		}
+	}
+
+	// Port: only apply when not set by .shippy.yaml
+	if opts.Port == 0 {
+		if portStr := get(alias, "Port"); portStr != "" {
+			if port, err := strconv.Atoi(portStr); err == nil && port > 0 {
+				opts.Port = port
+			}
+		}
+	}
+
+	if opts.User == "" {
+		if user := get(alias, "User"); user != "" {
+			opts.User = user
+		}
+	}
+
+	if opts.KeyPath == "" {
+		if identityFile := get(alias, "IdentityFile"); identityFile != "" {
+			opts.KeyPath = identityFile
+		}
+	}
+}

--- a/internal/ssh/sshconfig_test.go
+++ b/internal/ssh/sshconfig_test.go
@@ -1,0 +1,113 @@
+package ssh
+
+import "testing"
+
+// testGetter returns a getter backed by a static map, simulating ~/.ssh/config entries.
+func testGetter(cfg map[string]map[string]string) func(string, string) string {
+	return func(alias, key string) string {
+		if host, ok := cfg[alias]; ok {
+			return host[key]
+		}
+		return ""
+	}
+}
+
+func TestApplyConfigFillsMissingValues(t *testing.T) {
+	get := testGetter(map[string]map[string]string{
+		"myhost": {
+			"ProxyCommand": "/usr/bin/nc %h %p",
+			"Port":         "2222",
+			"User":         "admin",
+			"IdentityFile": "/home/user/.ssh/mykey",
+		},
+	})
+
+	opts := ClientOptions{Host: "myhost"}
+	applyConfig(&opts, get)
+
+	if opts.ProxyCommand != "/usr/bin/nc %h %p" {
+		t.Errorf("ProxyCommand = %q, want %q", opts.ProxyCommand, "/usr/bin/nc %h %p")
+	}
+	if opts.Port != 2222 {
+		t.Errorf("Port = %d, want 2222", opts.Port)
+	}
+	if opts.User != "admin" {
+		t.Errorf("User = %q, want %q", opts.User, "admin")
+	}
+	if opts.KeyPath != "/home/user/.ssh/mykey" {
+		t.Errorf("KeyPath = %q, want %q", opts.KeyPath, "/home/user/.ssh/mykey")
+	}
+}
+
+func TestApplyConfigDoesNotOverwriteExistingValues(t *testing.T) {
+	get := testGetter(map[string]map[string]string{
+		"myhost": {
+			"ProxyCommand": "config_cmd",
+			"Port":         "2222",
+			"User":         "config_user",
+			"IdentityFile": "/config/key",
+		},
+	})
+
+	opts := ClientOptions{
+		Host:         "myhost",
+		ProxyCommand: "shippy_cmd",
+		Port:         22,
+		User:         "shippy_user",
+		KeyPath:      "/shippy/key",
+	}
+	applyConfig(&opts, get)
+
+	if opts.ProxyCommand != "shippy_cmd" {
+		t.Errorf("ProxyCommand overwritten: got %q, want %q", opts.ProxyCommand, "shippy_cmd")
+	}
+	if opts.Port != 22 {
+		t.Errorf("Port overwritten: got %d, want 22", opts.Port)
+	}
+	if opts.User != "shippy_user" {
+		t.Errorf("User overwritten: got %q, want %q", opts.User, "shippy_user")
+	}
+	if opts.KeyPath != "/shippy/key" {
+		t.Errorf("KeyPath overwritten: got %q, want %q", opts.KeyPath, "/shippy/key")
+	}
+}
+
+func TestApplyConfigNoMatchLeavesOptsUnchanged(t *testing.T) {
+	get := testGetter(map[string]map[string]string{
+		"otherhost": {"ProxyCommand": "some_cmd"},
+	})
+
+	opts := ClientOptions{Host: "myhost"}
+	applyConfig(&opts, get)
+
+	if opts.ProxyCommand != "" || opts.Port != 0 || opts.User != "" || opts.KeyPath != "" {
+		t.Errorf("opts should be unchanged for unknown host, got: %+v", opts)
+	}
+}
+
+func TestApplyConfigInvalidPortIgnored(t *testing.T) {
+	get := testGetter(map[string]map[string]string{
+		"myhost": {"Port": "notanumber"},
+	})
+
+	opts := ClientOptions{Host: "myhost"}
+	applyConfig(&opts, get)
+
+	if opts.Port != 0 {
+		t.Errorf("invalid port should be ignored, got %d", opts.Port)
+	}
+}
+
+func TestApplyConfigZeroPortFromConfig(t *testing.T) {
+	get := testGetter(map[string]map[string]string{
+		"myhost": {"Port": "0"},
+	})
+
+	opts := ClientOptions{Host: "myhost"}
+	applyConfig(&opts, get)
+
+	// Port 0 in config is treated as invalid (must be > 0)
+	if opts.Port != 0 {
+		t.Errorf("port 0 in config should be ignored, got %d", opts.Port)
+	}
+}


### PR DESCRIPTION
Go uses direct syscalls for TCP connections, bypassing the libc layer that corporate endpoint protection (e.g. Microsoft Defender Network Extension) hooks into. This causes EHOSTUNREACH for Go binaries on managed machines even when system tools like nc and ssh connect fine.

ProxyCommand delegates the TCP socket to a trusted system binary, with the SSH handshake running over its stdio. Set via ~/.ssh/config or .shippy.yaml:

  ssh_options:
    ProxyCommand: "/usr/bin/nc %h %p"

Also reads Hostname, Port, User and IdentityFile from ~/.ssh/config as fallbacks, matching the behaviour users expect from the system ssh command.