### PR TITLE
[BUGFIX] Replace rsync -a with -rlt --no-perms to preserve server ACLs

### DIFF
--- a/internal/rsync/transfer.go
+++ b/internal/rsync/transfer.go
@@ -146,7 +146,7 @@ func (s *Syncer) Sync(files []FileInfo) error {
 
 	// Use rsync on the remote server to copy from cache to release
 	// --delete removes files that only exist in release (not in cache)
-	copyCmd := fmt.Sprintf("rsync -a --delete %s/ %s/", ssh.Quote(cachePath), ssh.Quote(s.remotePath))
+	copyCmd := fmt.Sprintf("rsync -rlt --no-perms --delete %s/ %s/", ssh.Quote(cachePath), ssh.Quote(s.remotePath))
 	output, err := s.client.RunCommand(copyCmd)
 	if err != nil {
 		return fmt.Errorf("failed to copy from cache to release: %w (output: %s)", err, output)

--- a/internal/rsync/transfer_test.go
+++ b/internal/rsync/transfer_test.go
@@ -98,7 +98,7 @@ func TestSyncQuotesRemoteCommands(t *testing.T) {
 	if !f.saw("rm -f '/srv/my app/.cache/old data.txt'") {
 		t.Errorf("expected quoted deletion of stale cache file, commands: %v", f.commands)
 	}
-	if !f.saw("rsync -a --delete '/srv/my app/.cache'/ '/srv/my app/releases/20240105120000'/") {
+	if !f.saw("rsync -rlt --no-perms --delete '/srv/my app/.cache'/ '/srv/my app/releases/20240105120000'/") {
 		t.Errorf("expected quoted rsync copy, commands: %v", f.commands)
 	}
 
@@ -144,6 +144,54 @@ func TestSyncSkipsUnchangedFiles(t *testing.T) {
 	}
 	if f.saw("rm -f") {
 		t.Errorf("expected no deletions, commands: %v", f.commands)
+	}
+}
+
+// TestSyncCacheToReleaseFlags verifies that the remote rsync command used to
+// promote the cache into the release directory never sets file permissions from
+// the source tree. Server permissions are owned by the server (default ACLs,
+// umask) not by the deploying machine; mirroring source permissions via -a or
+// --perms would silently override those ACLs and break group-write access for
+// the web server process.
+func TestSyncCacheToReleaseFlags(t *testing.T) {
+	var rsyncCmd string
+	f := &fakeClient{respond: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "rsync") {
+			rsyncCmd = cmd
+		}
+		return "", nil
+	}}
+
+	s := NewSyncer(f, spacedDeploy+"/releases/20240105120000", false, spacedDeploy)
+	files := []FileInfo{
+		{RelPath: "index.php", FullPath: "/local/index.php", Size: 1, Mode: 0o644, ModTime: time.Unix(1000, 0)},
+	}
+	if err := s.Sync(files); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	if rsyncCmd == "" {
+		t.Fatal("no rsync command was issued")
+	}
+
+	// --no-perms must be present so chmod() is never called on transferred files.
+	if !strings.Contains(rsyncCmd, "--no-perms") {
+		t.Errorf("rsync command must contain --no-perms to let server ACLs govern permissions, got: %s", rsyncCmd)
+	}
+
+	// -a (archive) implies -p/--perms which calls chmod() and overrides default
+	// ACLs. Neither form must appear in the command.
+	for _, forbidden := range []string{"-a ", "-a\t", " -a\n", "--archive", "--perms", " -p "} {
+		if strings.Contains(rsyncCmd, forbidden) {
+			t.Errorf("rsync command must not contain %q (would mirror source permissions and override server ACLs), got: %s", forbidden, rsyncCmd)
+		}
+	}
+
+	// Recursive, links, and timestamps must be preserved.
+	for _, required := range []string{"-rlt", "--delete"} {
+		if !strings.Contains(rsyncCmd, required) {
+			t.Errorf("rsync command must contain %q, got: %s", required, rsyncCmd)
+		}
 	}
 }
 


### PR DESCRIPTION
rsync's -a (archive) flag bundles -rlptgoD, which includes -p/--perms. That flag calls chmod() on every transferred file, stamping source permissions from the deploy machine onto the server. The side-effect is that it resets the ACL mask, silently overriding any default ACLs set on the destination and breaking group-write access for the web server process.

Permission preservation belongs in backup tools, not deployment tools. A deployment should place files on the server and let the server's own policy govern how they are accessed — via umask, default ACLs, and group ownership. -rlt preserves the necessary semantics (recursive, symlinks, timestamps) while --no-perms skips chmod() entirely, so new files are created through the normal open() + umask + ACL inheritance path.