### PR TITLE
[BUGFIX] Make deployment lock acquisition atomic

### DIFF
--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,6 +1,8 @@
 package lock
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,6 +13,13 @@ import (
 	"github.com/ochorocho/shippy/internal/ssh"
 )
 
+const acquireMaxAttempts = 5
+
+// lockRetryBackoff is how long Acquire waits before re-checking a lock whose
+// metadata is not yet readable (another deploy is mid-acquire between creating
+// the lock directory and writing info.json).
+const lockRetryBackoff = 100 * time.Millisecond
+
 // LockInfo contains metadata about a deployment lock
 type LockInfo struct {
 	LockedBy  string    `json:"locked_by"`
@@ -18,6 +27,7 @@ type LockInfo struct {
 	ExpiresAt time.Time `json:"expires_at"`
 	Message   string    `json:"message"`
 	PID       int       `json:"pid"`
+	Token     string    `json:"token"` // set per acquire; Release only removes the lock when it matches
 }
 
 // commandRunner is the subset of *ssh.Client that the locker needs. Defining
@@ -32,7 +42,10 @@ type Locker struct {
 	client     commandRunner
 	deployPath string
 	timeout    time.Duration
-	lockPath   string
+	shippyDir  string
+	lockDir    string
+	infoPath   string
+	token      string
 }
 
 // NewLocker creates a new deployment locker
@@ -41,131 +54,204 @@ func NewLocker(client commandRunner, deployPath string, timeout time.Duration) *
 		timeout = time.Duration(config.DefaultLockTimeoutMinutes) * time.Minute // Default like Capistrano
 	}
 
+	shippyDir := deployPath + "/.shippy"
+	lockDir := shippyDir + "/deploy.lock"
+
 	return &Locker{
 		client:     client,
 		deployPath: deployPath,
 		timeout:    timeout,
-		lockPath:   deployPath + "/.shippy/deploy.lock",
+		shippyDir:  shippyDir,
+		lockDir:    lockDir,
+		infoPath:   lockDir + "/info.json",
+		token:      newToken(),
 	}
+}
+
+func newToken() string {
+	hostname, _ := os.Hostname()
+	var randomBytes [8]byte
+	// #nosec G104 -- a short read is impossible; a zero suffix is still usable.
+	_, _ = rand.Read(randomBytes[:])
+	return fmt.Sprintf("%s-%d-%d-%s", hostname, os.Getpid(), time.Now().UnixNano(), hex.EncodeToString(randomBytes[:]))
 }
 
 // Acquire attempts to acquire the deployment lock
 func (l *Locker) Acquire(message string) error {
-	// Check if lock exists and is still valid
-	locked, info, err := l.IsLocked()
-	if err != nil {
-		return fmt.Errorf("failed to check lock status: %w", err)
+	var lastCreateFailure string
+
+	for attempt := 0; attempt < acquireMaxAttempts; attempt++ {
+		created, output, err := l.tryCreate(message)
+		if err != nil {
+			return err
+		}
+		if created {
+			return nil
+		}
+
+		exists, err := l.lockDirExists()
+		if err != nil {
+			return err
+		}
+		if !exists {
+			// mkdir failed but nothing is there: either the lock was released
+			// between the create and this probe (a retry then wins) or the
+			// create genuinely failed (permissions, full disk). Retry; if every
+			// attempt fails this way, surface the real create output below.
+			lastCreateFailure = strings.TrimSpace(output)
+			continue
+		}
+		lastCreateFailure = ""
+
+		info, err := l.readInfo()
+		switch {
+		case err == nil && info != nil && time.Now().Before(info.ExpiresAt):
+			// A valid lock is held.
+			return l.lockedError(info)
+		case err == nil && info != nil:
+			// Expired: steal it atomically and retry.
+			l.steal()
+		default:
+			// Metadata not yet readable: another deploy is mid-acquire between
+			// creating the directory and writing info.json. Wait and re-check
+			// rather than stealing a lock that was just legitimately taken.
+			time.Sleep(lockRetryBackoff)
+		}
 	}
 
-	if locked {
-		// Lock exists and is not expired
-		timeLeft := time.Until(info.ExpiresAt)
-		minutesLeft := int(timeLeft.Minutes())
-
-		return fmt.Errorf("deployment is locked\n\n"+
-			"  Locked by: %s\n"+
-			"  Locked at: %s\n"+
-			"  Expires:   %s (in %d minutes)\n"+
-			"  Message:   %s\n\n"+
-			"To unlock manually, run:\n"+
-			"  shippy unlock\n\n"+
-			"Or wait for automatic expiry in %d minutes.",
-			info.LockedBy,
-			info.LockedAt.Format("2006-01-02 15:04:05"),
-			info.ExpiresAt.Format("2006-01-02 15:04:05"),
-			minutesLeft,
-			info.Message,
-			minutesLeft,
-		)
+	if lastCreateFailure != "" {
+		return fmt.Errorf("failed to create deployment lock: %s", lastCreateFailure)
 	}
+	return fmt.Errorf("could not acquire deployment lock after %d attempts", acquireMaxAttempts)
+}
 
-	// Create lock
+// tryCreate attempts the atomic create. It returns (true, "", nil) when this
+// process won the lock and (false, output, nil) when the create command failed
+// (the caller inspects whether lockDir exists to tell contention from a real
+// failure). The error return is only for a local failure (marshalling).
+func (l *Locker) tryCreate(message string) (bool, string, error) {
 	hostname, _ := os.Hostname()
 	username := os.Getenv("USER")
 	if username == "" {
 		username = "unknown"
 	}
 
+	now := time.Now()
 	lockInfo := LockInfo{
 		LockedBy:  fmt.Sprintf("%s@%s", username, hostname),
-		LockedAt:  time.Now(),
-		ExpiresAt: time.Now().Add(l.timeout),
+		LockedAt:  now,
+		ExpiresAt: now.Add(l.timeout),
 		Message:   message,
 		PID:       os.Getpid(),
+		Token:     l.token,
 	}
 
-	// Marshal to JSON
 	data, err := json.MarshalIndent(lockInfo, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal lock info: %w", err)
+		return false, "", fmt.Errorf("failed to marshal lock info: %w", err)
 	}
 
-	// Ensure .shippy directory exists
-	shippyDir := l.deployPath + "/.shippy"
-	if _, err := l.client.RunCommand(fmt.Sprintf("mkdir -p %s", ssh.Quote(shippyDir))); err != nil {
-		return fmt.Errorf("failed to create .shippy directory: %w", err)
-	}
+	// One command, narrowing the window with a lock dir but no info.json: mkdir
+	// (no -p, so it fails if another racer won) then write the metadata. The
+	// quoted 'EOF' stops the shell expanding the JSON; only paths are quoted.
+	cmd := fmt.Sprintf("mkdir -p %s && mkdir %s && cat > %s << 'EOF'\n%s\nEOF",
+		ssh.Quote(l.shippyDir), ssh.Quote(l.lockDir), ssh.Quote(l.infoPath), string(data))
 
-	// Write lock file. The heredoc body is JSON delimited by a quoted 'EOF'
-	// marker, so the shell performs no expansion on it; only lockPath is
-	// interpolated as a shell word and must be quoted.
-	cmd := fmt.Sprintf("cat > %s << 'EOF'\n%s\nEOF", ssh.Quote(l.lockPath), string(data))
-	if _, err := l.client.RunCommand(cmd); err != nil {
-		return fmt.Errorf("failed to create lock file: %w", err)
+	if output, err := l.client.RunCommand(cmd); err != nil {
+		return false, output, nil
 	}
-
-	return nil
+	return true, "", nil
 }
 
-// Release removes the deployment lock
-func (l *Locker) Release() error {
-	cmd := fmt.Sprintf("rm -f %s", ssh.Quote(l.lockPath))
-	_, err := l.client.RunCommand(cmd)
-	// Ignore errors - lock might not exist
-	return err
-}
-
-// IsLocked checks if a valid (non-expired) lock exists
-func (l *Locker) IsLocked() (bool, *LockInfo, error) {
-	// Check if lock file exists
-	output, err := l.client.RunCommand(fmt.Sprintf("cat %s 2>/dev/null || echo ''", ssh.Quote(l.lockPath)))
+// lockDirExists reports whether the lock directory currently exists.
+func (l *Locker) lockDirExists() (bool, error) {
+	output, err := l.client.RunCommand(fmt.Sprintf("[ -d %s ] && echo yes || echo no", ssh.Quote(l.lockDir)))
 	if err != nil {
-		// Command failed but we got output - parse it anyway
+		return false, fmt.Errorf("failed to check lock directory: %w", err)
+	}
+	return strings.TrimSpace(output) == "yes", nil
+}
+
+// steal renames the existing lock dir away, then removes it. rename is atomic,
+// so exactly one racer wins; losers' rename fails harmlessly and they retry.
+func (l *Locker) steal() {
+	stalePath := l.lockDir + ".stale." + l.token
+	if _, err := l.client.RunCommand(fmt.Sprintf("mv %s %s", ssh.Quote(l.lockDir), ssh.Quote(stalePath))); err != nil {
+		return
+	}
+	_, _ = l.client.RunCommand(fmt.Sprintf("rm -rf %s", ssh.Quote(stalePath)))
+}
+
+func (l *Locker) lockedError(info *LockInfo) error {
+	minutesLeft := int(time.Until(info.ExpiresAt).Minutes())
+	return fmt.Errorf("deployment is locked\n\n"+
+		"  Locked by: %s\n"+
+		"  Locked at: %s\n"+
+		"  Expires:   %s (in %d minutes)\n"+
+		"  Message:   %s\n\n"+
+		"To unlock manually, run:\n"+
+		"  shippy unlock\n\n"+
+		"Or wait for automatic expiry in %d minutes.",
+		info.LockedBy,
+		info.LockedAt.Format("2006-01-02 15:04:05"),
+		info.ExpiresAt.Format("2006-01-02 15:04:05"),
+		minutesLeft,
+		info.Message,
+		minutesLeft,
+	)
+}
+
+// readInfo returns (nil, nil) when no metadata exists and (nil, err) when it is
+// present but unparseable.
+func (l *Locker) readInfo() (*LockInfo, error) {
+	output, err := l.client.RunCommand(fmt.Sprintf("cat %s 2>/dev/null || echo ''", ssh.Quote(l.infoPath)))
+	if err != nil {
 		output = strings.TrimSpace(output)
 		if output == "" {
-			// No lock file exists
-			return false, nil, nil
+			return nil, nil
 		}
 	}
 
 	output = strings.TrimSpace(output)
 	if output == "" {
-		// No lock file exists
-		return false, nil, nil
+		return nil, nil
 	}
 
-	// Parse lock file
 	var info LockInfo
 	if err := json.Unmarshal([]byte(output), &info); err != nil {
-		// Lock file exists but is corrupted - treat as stale
-		_ = l.ForceUnlock()
+		return nil, fmt.Errorf("corrupt lock metadata: %w", err)
+	}
+	return &info, nil
+}
+
+// Release removes the deployment lock
+func (l *Locker) Release() error {
+	info, err := l.readInfo()
+	if err != nil || info == nil || info.Token != l.token {
+		return nil
+	}
+	_, err = l.client.RunCommand(fmt.Sprintf("rm -rf %s", ssh.Quote(l.lockDir)))
+	return err
+}
+
+// IsLocked checks if a valid (non-expired) lock exists
+func (l *Locker) IsLocked() (bool, *LockInfo, error) {
+	info, err := l.readInfo()
+	if err != nil || info == nil {
 		return false, nil, nil
 	}
 
-	// Check if lock has expired
 	if time.Now().After(info.ExpiresAt) {
-		// Lock expired - remove it
-		_ = l.ForceUnlock()
 		return false, nil, nil
 	}
 
-	// Valid lock exists
-	return true, &info, nil
+	return true, info, nil
 }
 
 // ForceUnlock removes the lock regardless of ownership or expiry
 func (l *Locker) ForceUnlock() error {
-	return l.Release()
+	_, err := l.client.RunCommand(fmt.Sprintf("rm -rf %s", ssh.Quote(l.lockDir)))
+	return err
 }
 
 // RenewLock extends the lock expiry time
@@ -189,7 +275,7 @@ func (l *Locker) RenewLock() error {
 		return fmt.Errorf("failed to marshal lock info: %w", err)
 	}
 
-	cmd := fmt.Sprintf("cat > %s << 'EOF'\n%s\nEOF", ssh.Quote(l.lockPath), string(data))
+	cmd := fmt.Sprintf("cat > %s << 'EOF'\n%s\nEOF", ssh.Quote(l.infoPath), string(data))
 	if _, err := l.client.RunCommand(cmd); err != nil {
 		return fmt.Errorf("failed to renew lock: %w", err)
 	}

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,10 +1,16 @@
 package lock
 
 import (
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 )
+
+// errFake stands in for a non-zero remote exit (e.g. mkdir failing on an
+// existing directory).
+var errFake = errors.New("non-zero exit")
 
 // fakeRunner records every command issued and returns canned responses.
 type fakeRunner struct {
@@ -33,73 +39,234 @@ func (f *fakeRunner) sawContaining(substr string) bool {
 // would split the command into multiple arguments and corrupt the operation.
 const spacedDeployPath = "/var/www/my app"
 
-func TestNewLockerDerivesLockPath(t *testing.T) {
-	l := NewLocker(&fakeRunner{}, spacedDeployPath, 0)
-	want := spacedDeployPath + "/.shippy/deploy.lock"
-	if l.lockPath != want {
-		t.Errorf("lockPath = %q, want %q", l.lockPath, want)
+func lockJSON(t *testing.T, info LockInfo) string {
+	t.Helper()
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal lock info: %v", err)
 	}
+	return string(data)
 }
 
-func TestAcquireQuotesPaths(t *testing.T) {
-	f := &fakeRunner{} // default response "" => no existing lock
+func TestAcquireCreatesLockDirAtomicallyAndQuotes(t *testing.T) {
+	// Default response "" with nil error => mkdir chain "succeeds" => we win.
+	f := &fakeRunner{}
 	l := NewLocker(f, spacedDeployPath, 15*time.Minute)
 
 	if err := l.Acquire("deploying"); err != nil {
 		t.Fatalf("Acquire() error = %v", err)
 	}
 
-	if !f.sawContaining("mkdir -p '/var/www/my app/.shippy'") {
-		t.Errorf("expected quoted mkdir of .shippy dir, commands: %v", f.commands)
+	// The acquire is a single atomic command: mkdir lockDir (no -p) + write info.json.
+	if !f.sawContaining("mkdir -p '/var/www/my app/.shippy' && mkdir '/var/www/my app/.shippy/deploy.lock' && cat > '/var/www/my app/.shippy/deploy.lock/info.json' << 'EOF'") {
+		t.Errorf("expected atomic quoted mkdir+write, commands: %v", f.commands)
 	}
-	if !f.sawContaining("cat > '/var/www/my app/.shippy/deploy.lock' << 'EOF'") {
-		t.Errorf("expected quoted heredoc write of lock file, commands: %v", f.commands)
+	// The metadata must carry our token so Release can verify ownership.
+	if !f.sawContaining(`"token": "` + l.token) {
+		t.Errorf("expected token %q embedded in lock metadata, commands: %v", l.token, f.commands)
 	}
 }
 
-func TestReleaseQuotesPath(t *testing.T) {
+func TestAcquireFailsWhenValidLockHeld(t *testing.T) {
+	other := lockJSON(t, LockInfo{
+		LockedBy:  "alice@host",
+		ExpiresAt: time.Now().Add(time.Hour),
+		Message:   "deploying",
+		Token:     "someone-elses-token",
+	})
+
+	f := &fakeRunner{respond: func(cmd string) (string, error) {
+		switch {
+		case strings.HasPrefix(cmd, "mkdir -p"):
+			return "mkdir: File exists", errFake // mkdir of lockDir fails: contended
+		case strings.HasPrefix(cmd, "[ -d"):
+			return "yes\n", nil // the lock directory really exists
+		case strings.HasPrefix(cmd, "cat "):
+			return other, nil
+		}
+		return "", nil
+	}}
+	l := NewLocker(f, spacedDeployPath, time.Minute)
+
+	err := l.Acquire("deploying")
+	if err == nil {
+		t.Fatal("Acquire() = nil, want 'deployment is locked' error")
+	}
+	if !strings.Contains(err.Error(), "deployment is locked") {
+		t.Errorf("Acquire() error = %v, want 'deployment is locked'", err)
+	}
+	// A valid lock must NOT be stolen.
+	if f.sawContaining("mv ") {
+		t.Errorf("valid lock was stolen (saw mv), commands: %v", f.commands)
+	}
+}
+
+func TestAcquireStealsExpiredLock(t *testing.T) {
+	expired := lockJSON(t, LockInfo{
+		LockedBy:  "bob@host",
+		ExpiresAt: time.Now().Add(-time.Hour),
+		Token:     "expired-token",
+	})
+
+	createAttempts := 0
+	f := &fakeRunner{respond: func(cmd string) (string, error) {
+		switch {
+		case strings.HasPrefix(cmd, "mkdir -p"):
+			createAttempts++
+			if createAttempts == 1 {
+				return "mkdir: File exists", errFake // first attempt: contended
+			}
+			return "", nil // after the steal, we win
+		case strings.HasPrefix(cmd, "[ -d"):
+			return "yes\n", nil
+		case strings.HasPrefix(cmd, "cat "):
+			return expired, nil
+		}
+		return "", nil
+	}}
+	l := NewLocker(f, spacedDeployPath, time.Minute)
+
+	if err := l.Acquire("deploying"); err != nil {
+		t.Fatalf("Acquire() error = %v, want success after stealing expired lock", err)
+	}
+	// Steal is an atomic rename of the lock dir, with our token in the target.
+	if !f.sawContaining("mv '/var/www/my app/.shippy/deploy.lock' '/var/www/my app/.shippy/deploy.lock.stale." + l.token) {
+		t.Errorf("expected atomic steal-by-rename, commands: %v", f.commands)
+	}
+}
+
+// A lock directory whose metadata is not yet readable (another deploy is
+// mid-acquire between mkdir and writing info.json) must NOT be stolen.
+func TestAcquireDoesNotStealLockWithMissingMetadata(t *testing.T) {
+	f := &fakeRunner{respond: func(cmd string) (string, error) {
+		switch {
+		case strings.HasPrefix(cmd, "mkdir -p"):
+			return "mkdir: File exists", errFake // always contended
+		case strings.HasPrefix(cmd, "[ -d"):
+			return "yes\n", nil // dir exists ...
+		case strings.HasPrefix(cmd, "cat "):
+			return "", nil // ... but info.json is not there yet
+		}
+		return "", nil
+	}}
+	l := NewLocker(f, spacedDeployPath, time.Minute)
+
+	if err := l.Acquire("deploying"); err == nil {
+		t.Fatal("Acquire() = nil, want failure when metadata never becomes readable")
+	}
+	if f.sawContaining("mv ") {
+		t.Errorf("stole a lock with unreadable metadata, commands: %v", f.commands)
+	}
+}
+
+// A create failure where the lock directory does NOT exist afterwards is a real
+// remote failure (permissions, full disk, ...) and must surface, not retry.
+func TestAcquireSurfacesRealCreateFailure(t *testing.T) {
+	f := &fakeRunner{respond: func(cmd string) (string, error) {
+		switch {
+		case strings.HasPrefix(cmd, "mkdir -p"):
+			return "mkdir: Permission denied", errFake
+		case strings.HasPrefix(cmd, "[ -d"):
+			return "no\n", nil // nothing was created
+		}
+		return "", nil
+	}}
+	l := NewLocker(f, spacedDeployPath, time.Minute)
+
+	err := l.Acquire("deploying")
+	if err == nil || !strings.Contains(err.Error(), "Permission denied") {
+		t.Errorf("Acquire() error = %v, want the real create failure surfaced", err)
+	}
+	if f.sawContaining("mv ") {
+		t.Errorf("attempted steal on a real failure, commands: %v", f.commands)
+	}
+}
+
+func TestReleaseOnlyRemovesOwnLock(t *testing.T) {
 	f := &fakeRunner{}
+	l := NewLocker(f, spacedDeployPath, time.Minute)
+	// info.json reports OUR token => Release should remove the dir.
+	f.respond = func(cmd string) (string, error) {
+		if strings.HasPrefix(cmd, "cat ") {
+			return lockJSON(t, LockInfo{Token: l.token, ExpiresAt: time.Now().Add(time.Hour)}), nil
+		}
+		return "", nil
+	}
+
+	if err := l.Release(); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+	if !f.sawContaining("rm -rf '/var/www/my app/.shippy/deploy.lock'") {
+		t.Errorf("expected quoted rm -rf of lock dir, commands: %v", f.commands)
+	}
+}
+
+func TestReleaseSkipsForeignLock(t *testing.T) {
+	f := &fakeRunner{respond: func(cmd string) (string, error) {
+		if strings.HasPrefix(cmd, "cat ") {
+			// A different token: another deploy holds the lock now.
+			return `{"token":"another-process","expires_at":"2999-01-01T00:00:00Z"}`, nil
+		}
+		return "", nil
+	}}
 	l := NewLocker(f, spacedDeployPath, time.Minute)
 
 	if err := l.Release(); err != nil {
 		t.Fatalf("Release() error = %v", err)
 	}
-	if !f.sawContaining("rm -f '/var/www/my app/.shippy/deploy.lock'") {
-		t.Errorf("expected quoted rm of lock file, commands: %v", f.commands)
+	if f.sawContaining("rm -rf") {
+		t.Errorf("Release removed a lock it does not own, commands: %v", f.commands)
 	}
 }
 
-func TestIsLockedReadsAndQuotes(t *testing.T) {
-	future := time.Now().Add(time.Hour)
-	lockJSON := `{"locked_by":"alice@host","locked_at":"` +
-		time.Now().Format(time.RFC3339) + `","expires_at":"` +
-		future.Format(time.RFC3339) + `","message":"deploying","pid":42}`
-
-	f := &fakeRunner{respond: func(string) (string, error) { return lockJSON, nil }}
+func TestForceUnlockRemovesDirUnconditionally(t *testing.T) {
+	f := &fakeRunner{}
 	l := NewLocker(f, spacedDeployPath, time.Minute)
 
-	locked, info, err := l.IsLocked()
+	if err := l.ForceUnlock(); err != nil {
+		t.Fatalf("ForceUnlock() error = %v", err)
+	}
+	if !f.sawContaining("rm -rf '/var/www/my app/.shippy/deploy.lock'") {
+		t.Errorf("expected unconditional quoted rm -rf, commands: %v", f.commands)
+	}
+	// ForceUnlock must not read metadata first — it removes regardless.
+	if f.sawContaining("cat ") {
+		t.Errorf("ForceUnlock should not inspect metadata, commands: %v", f.commands)
+	}
+}
+
+func TestIsLockedReadsValidLock(t *testing.T) {
+	info := LockInfo{
+		LockedBy:  "alice@host",
+		LockedAt:  time.Now(),
+		ExpiresAt: time.Now().Add(time.Hour),
+		Message:   "deploying",
+		PID:       42,
+	}
+	f := &fakeRunner{respond: func(string) (string, error) { return lockJSON(t, info), nil }}
+	l := NewLocker(f, spacedDeployPath, time.Minute)
+
+	locked, got, err := l.IsLocked()
 	if err != nil {
 		t.Fatalf("IsLocked() error = %v", err)
 	}
 	if !locked {
 		t.Fatal("IsLocked() = false, want true for a non-expired lock")
 	}
-	if info.LockedBy != "alice@host" || info.Message != "deploying" {
-		t.Errorf("parsed lock info = %+v", info)
+	if got.LockedBy != "alice@host" || got.Message != "deploying" {
+		t.Errorf("parsed lock info = %+v", got)
 	}
-	if !f.sawContaining("cat '/var/www/my app/.shippy/deploy.lock' 2>/dev/null") {
-		t.Errorf("expected quoted cat of lock file, commands: %v", f.commands)
+	if !f.sawContaining("cat '/var/www/my app/.shippy/deploy.lock/info.json' 2>/dev/null") {
+		t.Errorf("expected quoted cat of info.json, commands: %v", f.commands)
 	}
 }
 
-func TestIsLockedExpiredIsRemoved(t *testing.T) {
-	past := time.Now().Add(-time.Hour)
-	lockJSON := `{"locked_by":"bob@host","locked_at":"` +
-		past.Add(-time.Hour).Format(time.RFC3339) + `","expires_at":"` +
-		past.Format(time.RFC3339) + `","message":"old","pid":1}`
-
-	f := &fakeRunner{respond: func(string) (string, error) { return lockJSON, nil }}
+func TestIsLockedIsSideEffectFreeForExpiredLock(t *testing.T) {
+	expired := lockJSON(t, LockInfo{
+		LockedBy:  "bob@host",
+		ExpiresAt: time.Now().Add(-time.Hour),
+	})
+	f := &fakeRunner{respond: func(string) (string, error) { return expired, nil }}
 	l := NewLocker(f, spacedDeployPath, time.Minute)
 
 	locked, _, err := l.IsLocked()
@@ -109,9 +276,9 @@ func TestIsLockedExpiredIsRemoved(t *testing.T) {
 	if locked {
 		t.Error("IsLocked() = true, want false for an expired lock")
 	}
-	// Expired lock must be cleaned up with a quoted rm.
-	if !f.sawContaining("rm -f '/var/www/my app/.shippy/deploy.lock'") {
-		t.Errorf("expected expired lock to be removed, commands: %v", f.commands)
+	// IsLocked must be pure: no rm/mv side effects (Acquire/unlock handle cleanup).
+	if f.sawContaining("rm ") || f.sawContaining("mv ") {
+		t.Errorf("IsLocked mutated remote state, commands: %v", f.commands)
 	}
 }
 

--- a/tests/config-test/lock-race.yaml
+++ b/tests/config-test/lock-race.yaml
@@ -1,0 +1,19 @@
+# Minimal, fast config for the concurrent-deploy lock race test.
+# No TYPO3 setup — a single trivial command keeps the lock held briefly so two
+# simultaneous deploys genuinely contend for the deployment lock.
+rsync_src: .
+keep_releases: 2
+
+commands:
+  - name: Hold the lock briefly
+    run: sleep 2
+
+hosts:
+  production:
+    hostname: 127.0.0.1
+    port: 2424
+    remote_user: root
+    deploy_path: /var/www/html
+    ssh_key: ../ssh_keys/shippy_key
+    ssh_options:
+      StrictHostKeyChecking: accept-new

--- a/tests/test_integration.bats
+++ b/tests/test_integration.bats
@@ -89,3 +89,47 @@ teardown() {
   run bash -c "ls ${out_dir}/backup-production-*.zip"
   assert_success
 }
+
+@test "Concurrent deploys contend for the lock - exactly one is rejected" {
+  set -eu -o pipefail
+
+  # Use the lightweight lock-race config (a single `sleep` command) so the
+  # winning deploy holds the lock briefly without running the full TYPO3 setup.
+  # ssh_key '../ssh_keys/shippy_key' resolves relative to this directory.
+  cd "$BATS_TEST_DIRNAME/config-test"
+
+  out1="${BATS_TMPDIR}/shippy-lock-race-1.log"
+  out2="${BATS_TMPDIR}/shippy-lock-race-2.log"
+  rm -f "$out1" "$out2"
+
+  # Launch two deploys as simultaneously as possible so both race for the lock.
+  ${BIN} deploy production --config lock-race.yaml >"$out1" 2>&1 &
+  pid1=$!
+  ${BIN} deploy production --config lock-race.yaml >"$out2" 2>&1 &
+  pid2=$!
+
+  wait "$pid1" || true
+  wait "$pid2" || true
+
+  # Exactly one run must win (deploy succeeds) and exactly one must be rejected
+  # by the lock. Asserting both guards against a false pass where the winner
+  # fails for an unrelated reason while the loser is still rejected.
+  locked_count=0
+  success_count=0
+  for f in "$out1" "$out2"; do
+    if grep -q "deployment is locked" "$f"; then
+      locked_count=$((locked_count + 1))
+    fi
+    if grep -q "Deployment completed successfully" "$f"; then
+      success_count=$((success_count + 1))
+    fi
+  done
+
+  if [ "$locked_count" -ne 1 ] || [ "$success_count" -ne 1 ]; then
+    echo "Expected exactly 1 success and 1 lock rejection, got success=${success_count} locked=${locked_count}"
+    echo "----- run 1 -----"; cat "$out1"
+    echo "----- run 2 -----"; cat "$out2"
+  fi
+  [ "$success_count" -eq 1 ]
+  [ "$locked_count" -eq 1 ]
+}


### PR DESCRIPTION
## The problem

The deployment lock was not really safe against two deploys at the same time.

`Acquire()` did two separate steps: first check if a lock exists, then write the
lock file. If two deploys run together, both see "no lock" and both write it, so
both think they got the lock. And `Release()` removed the lock without checking
who owns it, so one deploy could delete another deploy's lock.

## The fix

Now the lock is a **directory** created with `mkdir`. `mkdir` is atomic on POSIX
and NFS, so only one deploy can create it - the others fail. The metadata (who,
when, token) is written into `info.json` inside that directory.

- `Release()` only removes the lock when the token matches, so a deploy can not
  delete a lock it does not own.
- An expired lock is taken over with an atomic rename, so two deploys can not
  "steal" it at the same time.
- If the metadata is not readable yet (another deploy is just creating it right
  now), we wait a bit and retry instead of stealing the lock.
- If `mkdir` fails but nothing is there, we retry. A real error (no permission,
  disk full) is reported, not hidden.

This is the same approach Capistrano/Deployer use. I checked existing Go locking
libraries first, but none fit here because they need a mounted filesystem or an
extra service - shippy only has a plain SSH shell.

## Note (breaking)

The lock on disk changes from a file to a directory. There is no migration (we
are still alpha). If you have an old stuck lock, just delete
`<deploy_path>/.shippy/deploy.lock` on the server once.

## Testing

- New integration test: two deploys at the same time -> exactly one wins, one is
  rejected with "deployment is locked".
- I also ran a real concurrency test against the test container (8 parallel
  workers, 300+ acquire/release). New code: never more than 1 holder at a time.
  Old code: up to 8 holders at the same time.
- `go vet`, `go test ./...` and the bats suite are green.