### PR TITLE
Include `brew trust` command in install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ based PHP projects, inspired by Deployer and Capistrano.
 
 ```bash
 brew tap ochorocho/shippy https://github.com/ochorocho/shippy
+brew trust ochorocho/shippy
 brew install shippy
 ```
 


### PR DESCRIPTION
I got the following error on `brew install shippy`:

```
Error: Refusing to load formula ochorocho/shippy/shippy from untrusted tap ochorocho/shippy.
Run `brew trust --formula ochorocho/shippy/shippy` or `brew trust ochorocho/shippy` to trust it.
```

Hence, I added the `brew trust` command to the brew install guide.