### PR TITLE
[TASK] Replace Docker-based checksum action with sha256sum

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,9 @@ jobs:
         run: make build
 
       - name: Generate checksums
-        uses: Solratic/checksum-action@v1
-        with:
-          pattern: "dist/shippy"
-          suffix: "checksum"
+        shell: bash
+        working-directory: dist
+        run: sha256sum shippy > shippy.checksum
 
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v5.0.0


### PR DESCRIPTION
The Build workflow used Solratic/checksum-action@v1 to generate the per-artifact checksum. That action is a Docker-container action (FROM python:3.10-slim), so every build pulled python:3.10-slim from Docker Hub. A transient Docker Hub registry timeout failed the "Generate checksums" step, which failed the Build job, which left the Release workflow's Docker-push job with no artifact to download ("Unable to download artifact(s): Not Found").

Generating a checksum needs no container. Replace it with a plain `sha256sum` step. The output format (`<hash>  shippy`) is unchanged, so scripts/update-formula.sh (`awk '{print $1}'`) parses it identically. This removes the only Docker Hub dependency from the build path.