### PR TITLE
Add dry-run option

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/ochorocho/shippy/internal/composer"
 	"github.com/ochorocho/shippy/internal/deploy"
 	"github.com/ochorocho/shippy/internal/ui"
+	"github.com/spf13/cobra"
 )
 
 var (
 	verbose bool
+	dryRun  bool
 )
 
 var deployCmd = &cobra.Command{
@@ -37,6 +38,7 @@ Example:
 func init() {
 	rootCmd.AddCommand(deployCmd)
 	deployCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show detailed output for each file")
+	deployCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview which files and commands would be deployed without connecting to the host")
 }
 
 func runDeploy(cmd *cobra.Command, args []string) error {
@@ -79,6 +81,15 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		out.Error("Failed to create deployer: %v", err)
 		return err
+	}
+
+	// Dry run: preview files and commands without connecting to the host
+	if dryRun {
+		if err := deployer.DryRun(); err != nil {
+			out.Error("Dry run failed: %v", err)
+			return err
+		}
+		return nil
 	}
 
 	// Deploy!

--- a/internal/deploy/deployer.go
+++ b/internal/deploy/deployer.go
@@ -2,7 +2,9 @@ package deploy
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/ochorocho/shippy/internal/composer"
@@ -218,6 +220,92 @@ func (d *Deployer) Deploy() error {
 	out.HeaderGreen("Deployment completed successfully!")
 
 	return nil
+}
+
+// DryRun previews which files and commands would be deployed without
+// connecting to the remote host. The file scan runs entirely locally, so this
+// works even when the target is unreachable.
+func (d *Deployer) DryRun() error {
+	out := ui.New()
+
+	out.Header("Shippy - Dry Run (no changes will be made)")
+	out.Info("Target: %s (%s@%s:%s)", d.hostName, d.host.RemoteUser, d.host.Hostname, d.host.DeployPath)
+	fmt.Printf("\n")
+
+	// Scan files (local only, no SSH connection required)
+	out.StepNumber(1, "Scanning files")
+
+	scanOpts := rsync.SyncOptions{
+		SourceDir:       d.config.GetRsyncSrc(d.host),
+		ExcludePatterns: d.getExcludePatterns(),
+		IncludePatterns: d.config.GetInclude(d.host),
+		UseGitignore:    true,
+	}
+
+	scanner, err := rsync.NewScanner(scanOpts)
+	if err != nil {
+		return fmt.Errorf("failed to create scanner: %w", err)
+	}
+
+	files, err := scanner.Scan()
+	if err != nil {
+		return fmt.Errorf("failed to scan files: %w", err)
+	}
+
+	out.Success("Found %d files to sync", len(files))
+	d.printFileTree(out, files)
+
+	// Shared symlinks that would be created
+	sharedItems := d.config.GetShared(d.host)
+	if len(sharedItems) > 0 {
+		out.StepNumber(2, "Shared symlinks (%d)", len(sharedItems))
+		for _, item := range sharedItems {
+			out.Println("  %s", item)
+		}
+	}
+
+	// Commands that would be executed in the new release
+	if len(d.config.Commands) > 0 {
+		out.StepNumber(3, "Commands to execute (%d)", len(d.config.Commands))
+		for _, cmd := range d.config.Commands {
+			out.Println("  %s", cmd.Name)
+			out.Info("    $ %s", cmd.Run)
+		}
+	}
+
+	out.HeaderGreen("Dry run completed - nothing was deployed")
+
+	return nil
+}
+
+// printFileTree groups scanned files by directory. By default only directories
+// with their file count are shown; with verbose the individual files are listed.
+func (d *Deployer) printFileTree(out *ui.Output, files []rsync.FileInfo) {
+	groups := make(map[string][]string)
+	for _, f := range files {
+		dir := path.Dir(f.RelPath)
+		if dir == "." {
+			dir = "./"
+		}
+		groups[dir] = append(groups[dir], f.RelPath)
+	}
+
+	dirs := make([]string, 0, len(groups))
+	for dir := range groups {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	for _, dir := range dirs {
+		entries := groups[dir]
+		out.Println("  %s (%d files)", dir, len(entries))
+		if d.verbose {
+			sort.Strings(entries)
+			for _, rel := range entries {
+				out.Info("    %s", rel)
+			}
+		}
+	}
 }
 
 // getExcludePatterns returns the combined list of exclude patterns

--- a/tests/test_deploy.bats
+++ b/tests/test_deploy.bats
@@ -98,3 +98,39 @@ teardown() {
   assert_failure
   assert_output --partial "hostname is required"
 }
+
+@test "Should show dry-run flag in help" {
+  run -0 ${BIN} deploy --help
+  assert_success
+  assert_output --partial "--dry-run"
+}
+
+@test "Should preview files and commands with --dry-run without connecting" {
+  # minimal.yaml points at an unreachable host; --dry-run must still succeed
+  run -0 ${BIN} deploy production --dry-run --config ${BATS_TEST_DIRNAME}/config-test/minimal.yaml
+  assert_success
+  assert_output --partial "Dry Run"
+  assert_output --partial "Found"
+  assert_output --partial "files to sync"
+  # Directories are shown with a file count, not the individual files
+  assert_output --partial "files)"
+  # Default TYPO3 commands are listed
+  assert_output --partial "Commands to execute"
+  assert_output --partial "cache:flush"
+  assert_output --partial "nothing was deployed"
+}
+
+@test "Should not list individual files with --dry-run (non-verbose)" {
+  run -0 ${BIN} deploy production --dry-run --config ${BATS_TEST_DIRNAME}/config-test/minimal.yaml
+  assert_success
+  # composer.json is grouped under its directory, not printed as a file line
+  refute_output --partial "    composer.json"
+}
+
+@test "Should list individual files with --dry-run --verbose" {
+  mkdir -p public/css
+  echo "body{}" > public/css/main.css
+  run -0 ${BIN} deploy production --dry-run --verbose --config ${BATS_TEST_DIRNAME}/config-test/minimal.yaml
+  assert_success
+  assert_output --partial "public/css/main.css"
+}


### PR DESCRIPTION
shippy deploy now has a dry-run option to simulate/preview a deployment (without a ssh connection)