### PR TITLE
[!!!][FEATURE] Make deploy deny-by-default

### DIFF
--- a/.shippy.yaml.example
+++ b/.shippy.yaml.example
@@ -26,20 +26,23 @@ hosts:
     rsync_src: ./
     keep_releases: 5  # Number of releases to keep (default: 5)
 
-    # Optional: Additional exclude patterns (beyond .gitignore)
-    # Patterns support gitignore-style syntax
-    exclude:
-      - "*.log"              # Exclude all log files
-      - ".env.example"       # Exclude .env.example
-      - "tests/"             # Exclude tests directory
-      - ".ddev/"             # Exclude DDEV configuration
-      - "*.md"               # Exclude markdown files
-
-    # Optional: Force include files despite .gitignore
-    # Useful for including vendor/ or other gitignored deployment files
+    # File selection is DENY-BY-DEFAULT (an allowlist): nothing is deployed
+    # unless it is listed under 'include:' below. A directory entry ships that
+    # directory and everything beneath it. Note: .gitignore is NOT consulted for
+    # deployment - list what you want shipped explicitly.
     include:
-      - "public/.htaccess"   # Include .htaccess files
-      - "vendor/"
+      - "public/"            # Web root (ships everything under it)
+      - "vendor/"            # Composer dependencies
+      - "config/"            # TYPO3 configuration
+      - "composer.json"
+      - "composer.lock"
+
+    # Optional: Carve-outs. Excludes always WIN over includes, so use them to
+    # punch holes in an included directory. Common junk (.git/, node_modules/,
+    # var/cache/, .DS_Store, ...) is excluded automatically - no need to list it.
+    exclude:
+      - "public/typo3temp/"  # Don't ship generated temp files
+      - "*.log"              # Never ship log files
 
     # Shared files/directories (symlinked from shared/ to each release)
     shared:
@@ -58,6 +61,14 @@ hosts:
     ssh_key: ~/.ssh/id_rsa_production
     ssh_multiplexing: true  # Enable for faster deployments
     keep_releases: 10
+    # Deny-by-default: each host needs its own allowlist (include/exclude are not
+    # merged across hosts - a per-host list replaces the one above entirely).
+    include:
+      - "public/"
+      - "vendor/"
+      - "config/"
+      - "composer.json"
+      - "composer.lock"
     shared:
       - .env
       - var/log/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ based PHP projects, inspired by Deployer and Capistrano.
 - **Shared files/directories** - persistent data between releases
 - **Template variables** from composer.json
 - **Pure Go implementation** - single binary, no dependencies
-- **.gitignore support** - respects your gitignore patterns
+- **Deny-by-default file selection** - explicit allowlist, nothing ships unless you include it
 - **SSH-based** deployment with key authentication
 - **Colored output** - clear, beautiful deployment progress
 - **TYPO3 optimized** - sensible defaults for TYPO3 projects
@@ -68,6 +68,7 @@ Update at minimum:
 - `hostname` - your server's domain or IP
 - `remote_user` - SSH username
 - `ssh_key` - path to your SSH private key
+- `include` - the allowlist of paths to deploy (deny-by-default; adjust to your project layout)
 
 3. **Validate configuration**:
 
@@ -141,41 +142,24 @@ hosts:
 
     # File management
     shared: <list of shared paths>
-    exclude: <additional exclude patterns>
-    include: <patterns to include despite .gitignore>
+    include: <allowlist - paths to deploy (deny-by-default)>
+    exclude: <carve-outs that win over includes>
 
 commands:
   - name: <command description>
     run: <command to execute>
 ```
 
-### Exclude and Include Patterns
+### File Selection: Deny-by-Default (Allowlist)
 
-**Exclude Patterns:**
+Shippy deploys files using an **allowlist**: by default **nothing is deployed**
+unless it is listed under `include:`. A project root usually contains far more
+that should *not* ship (`.git/`, `node_modules/`, dumps, IDE files, `.env`) than
+should — an allowlist is safer and less error-prone than trying to exclude every
+unwanted path.
 
-Shippy automatically respects `.gitignore` patterns **including nested `.gitignore` files in subdirectories**. You can add additional exclude patterns in your configuration:
-
-```yaml
-hosts:
-  production:
-    hostname: example.com
-    remote_user: deploy
-    deploy_path: /var/www/myproject
-    rsync_src: ./
-
-    # Additional exclude patterns (beyond .gitignore)
-    exclude:
-      - "*.log"              # Exclude all .log files
-      - ".env.example"       # Exclude specific file
-      - "tests/"             # Exclude entire directory
-      - "*.md"               # Exclude all markdown files
-      - ".ddev/"             # Exclude DDEV configuration
-      - "node_modules/"      # Exclude node modules (if not in .gitignore)
-```
-
-**Include Patterns:**
-
-Use `include` to explicitly include files that are excluded by `.gitignore`:
+**Include = the allowlist.** List exactly what should ship. A directory entry
+ships that directory and everything beneath it:
 
 ```yaml
 hosts:
@@ -185,33 +169,59 @@ hosts:
     deploy_path: /var/www/myproject
     rsync_src: ./
 
-    # Force include files despite .gitignore
     include:
-      - "public/.htaccess"   # Include .htaccess files
-      - "vendor/"            # Include vendor directory (if gitignored)
-      - ".env.production"    # Include specific environment file
+      - "public/"            # Web root (ships the whole subtree)
+      - "vendor/"            # Composer dependencies
+      - "config/"            # TYPO3 configuration
+      - "composer.json"
+      - "composer.lock"
 ```
+
+**Exclude = carve-outs.** Excludes always **win over includes**, so use them to
+punch holes in an included directory:
+
+```yaml
+    exclude:
+      - "public/typo3temp/"  # Drop generated temp files under an included dir
+      - "*.log"              # Never ship log files
+```
+
+Common junk — `.git/`, `node_modules/`, `var/cache/`, `var/log/`, `.DS_Store`,
+`Thumbs.db` and more (see [Default Excludes](#default-excludes)) — is carved out
+automatically; you don't need to list it.
+
+**Notes:**
+
+- `include:`/`exclude:` are **not merged across hosts** — a per-host list
+  replaces the global one entirely. Give each host its own allowlist (or define
+  one at the global level and omit it per host).
+- `.gitignore` is **not** consulted for deployment. You select what ships with
+  `include:`; you don't rely on gitignore to deselect.
+- Escape hatch: `include: ["*"]` ships (almost) everything; the built-in junk
+  list still protects `.git/` etc.
 
 **Pattern Syntax:**
 
 - Patterns use gitignore-style syntax
-- `*` matches any characters except `/`
-- `**` matches any characters including `/`
+- A single-segment pattern (`vendor/`, `*.log`) matches at any depth
+- A multi-segment pattern (`public/index.php`) is anchored to the project root
 - Trailing `/` means directory only
-- No leading `/` means pattern matches at any depth
-- Leading `/` means pattern matches from project root
+- `*` matches within a path segment; `**` matches across segments
 
-**Examples:**
+### Migrating from a previous version
 
-```yaml
-exclude:
-  - "*.log"                    # All .log files at any depth
-  - "/build/"                  # build/ directory at root only
-  - "temp/"                    # temp/ directory at any depth
-  - "**/*.test.js"             # All .test.js files anywhere
-  - ".DS_Store"                # macOS metadata files
-  - "Thumbs.db"                # Windows metadata files
-```
+Earlier versions shipped **everything by default** and used `exclude:` (and
+`.gitignore`) to remove unwanted files. Deny-by-default reverses this:
+
+- **Add an `include:` allowlist to every host** (or globally). Without it,
+  `shippy deploy` scans **0 files** and warns you.
+- Existing `exclude:` entries still work, now as carve-outs on top of your
+  includes.
+- `.gitignore` no longer affects what is deployed — anything you relied on
+  gitignore to exclude is already excluded by default; anything gitignored that
+  you still need (e.g. `vendor/`) simply goes in `include:`.
+- Run `shippy config validate` and review `shippy deploy`'s "Found N files to
+  sync" count before your first real deploy.
 
 ### SSH Authentication
 
@@ -622,7 +632,7 @@ This command:
 
 When you run `shippy deploy <host>`, the following steps occur:
 
-1. **Scan files** - Walks source directory, respects .gitignore and exclude patterns
+1. **Scan files** - Walks source directory, applies the deny-by-default allowlist (include/exclude patterns)
 2. **Connect to server** - Establishes SSH connection
 3. **Create release** - Creates new timestamped release directory (e.g., `releases/20260109203841`)
 4. **Sync files** - Transfers files to the new release directory
@@ -645,6 +655,13 @@ hosts:
     deploy_path: /var/www/{{name}}
     rsync_src: ./
     ssh_key: ~/.ssh/id_rsa
+    # Deny-by-default: list exactly what should ship
+    include:
+      - public/
+      - vendor/
+      - config/
+      - composer.json
+      - composer.lock
     shared:
       - .env
       - var/log/
@@ -672,16 +689,18 @@ hosts:
     ssh_key: ~/.ssh/id_rsa
     keep_releases: 3
 
-    # Additional excludes beyond .gitignore
-    exclude:
-      - .git/
-      - node_modules/
-      - .env.local
-      - Tests/
-
-    # Force include despite .gitignore
+    # Allowlist: exactly what ships (deny-by-default)
     include:
-      - public/.htaccess
+      - public/
+      - vendor/
+      - config/
+      - composer.json
+      - composer.lock
+
+    # Carve-outs (win over includes). Common junk is already excluded.
+    exclude:
+      - public/typo3temp/
+      - Tests/
 
     # Shared paths
     shared:
@@ -698,6 +717,12 @@ hosts:
     rsync_src: ./
     ssh_key: ~/.ssh/id_rsa_production
     keep_releases: 10
+    include:
+      - public/
+      - vendor/
+      - config/
+      - composer.json
+      - composer.lock
     shared:
       - .env
       - var/log/
@@ -728,7 +753,8 @@ rollback_commands:
 
 ## Default Excludes
 
-Shippy automatically excludes these patterns (in addition to .gitignore):
+These carve-out patterns are always applied and **win over your `include:`
+allowlist**, so common junk never ships even inside an included directory:
 
 - `.git/`
 - `.gitignore`
@@ -764,7 +790,7 @@ shippy/
 │   ├── composer/
 │   │   └── parser.go    # Composer.json parser
 │   ├── rsync/
-│   │   ├── sync.go      # File scanner with gitignore
+│   │   ├── sync.go      # Allowlist file scanner (deny-by-default)
 │   │   └── transfer.go  # File transfer over SSH
 │   ├── ssh/
 │   │   ├── client.go    # SSH client

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -98,16 +98,22 @@ func generateMinimalConfig() string {
 #   - public/fileadmin/
 #   - public/uploads/
 
-# Optional: Files/patterns to exclude from deployment
-# exclude:
-#   - "*.log"
-#   - ".env.example"
-
-# Files/patterns to force-include despite .gitignore.
-# vendor/ is gitignored in most Composer projects but must be shipped, since
-# the server does not run "composer install" - keep it here.
+# File selection is deny-by-default: NOTHING is deployed unless it is listed in
+# 'include:' below. This is an allowlist - list exactly the paths that must ship.
+# A directory entry (e.g. public/) ships that directory and everything under it.
 include:
-  - "vendor/"
+  - "public/"        # Web root
+  - "vendor/"        # Composer dependencies (server does not run "composer install")
+  - "config/"        # TYPO3 site/system configuration
+  - "composer.json"
+  - "composer.lock"
+
+# Optional: Carve-outs. Excludes always win over includes, so use them to punch
+# holes in an included directory. Common junk (.git/, node_modules/, var/cache/,
+# .DS_Store, ...) is already excluded automatically.
+# exclude:
+#   - "public/typo3temp/"
+#   - "*.log"
 
 # Optional: Deployment locking (default: enabled, 15 min timeout)
 # lock_enabled: true

--- a/internal/deploy/deployer.go
+++ b/internal/deploy/deployer.go
@@ -67,11 +67,16 @@ func (d *Deployer) Deploy() error {
 	// Step 1: Scan files
 	out.StepNumber(1, "Scanning files")
 
+	includePatterns := d.config.GetInclude(d.host)
+	if len(includePatterns) == 0 {
+		out.Warning("No include patterns configured - deployment is deny-by-default, so nothing will be synced.")
+		out.Info("  Add an 'include:' allowlist (e.g. public/, vendor/, config/, composer.json) to your .shippy.yaml.")
+	}
+
 	scanOpts := rsync.SyncOptions{
 		SourceDir:       d.config.GetRsyncSrc(d.host),
 		ExcludePatterns: d.getExcludePatterns(),
-		IncludePatterns: d.config.GetInclude(d.host),
-		UseGitignore:    true,
+		IncludePatterns: includePatterns,
 	}
 
 	scanner, err := rsync.NewScanner(scanOpts)
@@ -235,11 +240,16 @@ func (d *Deployer) DryRun() error {
 	// Scan files (local only, no SSH connection required)
 	out.StepNumber(1, "Scanning files")
 
+	includePatterns := d.config.GetInclude(d.host)
+	if len(includePatterns) == 0 {
+		out.Warning("No include patterns configured - deployment is deny-by-default, so nothing will be synced.")
+		out.Info("  Add an 'include:' allowlist (e.g. public/, vendor/, config/, composer.json) to your .shippy.yaml.")
+	}
+
 	scanOpts := rsync.SyncOptions{
 		SourceDir:       d.config.GetRsyncSrc(d.host),
 		ExcludePatterns: d.getExcludePatterns(),
-		IncludePatterns: d.config.GetInclude(d.host),
-		UseGitignore:    true,
+		IncludePatterns: includePatterns,
 	}
 
 	scanner, err := rsync.NewScanner(scanOpts)
@@ -308,8 +318,13 @@ func (d *Deployer) printFileTree(out *ui.Output, files []rsync.FileInfo) {
 	}
 }
 
-// getExcludePatterns returns the combined list of exclude patterns
+// getExcludePatterns returns the carve-out patterns: the built-in junk list plus
+// any user-defined excludes. These always win over the include allowlist.
 func (d *Deployer) getExcludePatterns() []string {
-	// Combine default excludes with user-defined excludes (from config or host)
-	return append(defaultExcludePatterns, d.config.GetExclude(d.host)...)
+	// Start from a fresh slice so we never mutate the package-level
+	// defaultExcludePatterns backing array across calls.
+	excludes := make([]string, 0, len(defaultExcludePatterns)+len(d.config.GetExclude(d.host)))
+	excludes = append(excludes, defaultExcludePatterns...)
+	excludes = append(excludes, d.config.GetExclude(d.host)...)
+	return excludes
 }

--- a/internal/rsync/sync.go
+++ b/internal/rsync/sync.go
@@ -1,7 +1,6 @@
 package rsync
 
 import (
-	"bufio"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -25,35 +24,45 @@ type FileInfo struct {
 
 // SyncOptions contains options for file synchronization
 type SyncOptions struct {
-	SourceDir       string
+	SourceDir string
+	// ExcludePatterns are carve-outs: they always win over includes. This is the
+	// built-in junk list plus any user-defined exclude patterns.
 	ExcludePatterns []string
+	// IncludePatterns form the allowlist. Deployment is deny-by-default: a path is
+	// only synced when it (or an ancestor directory) matches an include pattern.
 	IncludePatterns []string
-	UseGitignore    bool
 }
 
-// Scanner scans files in a directory and determines which should be synced
+// Scanner scans files in a directory and determines which should be synced.
+//
+// Selection is deny-by-default (an allowlist): nothing is synced unless it
+// matches an include pattern. Excludes are carve-outs that win over includes, so
+// junk (.git/, node_modules/, ...) never ships even inside an included directory.
 type Scanner struct {
-	opts           SyncOptions
-	excludes       []gitignore.Pattern
-	includes       []gitignore.Pattern
-	gitignoreCache map[string][]gitignore.Pattern // Cache of .gitignore patterns by directory
+	opts     SyncOptions
+	excludes []gitignore.Pattern
+	includes []gitignore.Pattern
+	// rawIncludes keeps the original include pattern strings (without the leading
+	// "!"/"/") so we can decide whether to descend into a directory that is an
+	// ancestor of an anchored include target (e.g. descend into "public" for the
+	// include "public/index.php").
+	rawIncludes []string
 }
 
 // NewScanner creates a new file scanner
 func NewScanner(opts SyncOptions) (*Scanner, error) {
-	s := &Scanner{
-		opts:           opts,
-		gitignoreCache: make(map[string][]gitignore.Pattern),
-	}
+	s := &Scanner{opts: opts}
 
-	// Parse exclude patterns
+	// Parse exclude patterns (carve-outs)
 	for _, pattern := range opts.ExcludePatterns {
 		s.excludes = append(s.excludes, gitignore.ParsePattern(pattern, nil))
 	}
 
-	// Parse include patterns - prefix with ! to create negation patterns
-	// This allows them to override .gitignore exclusions
+	// Parse include patterns (allowlist). They are stored as gitignore negation
+	// patterns (prefixed with "!") so the matcher reports gitignore.Include on a
+	// match. The original strings are kept in rawIncludes for directory descent.
 	for _, pattern := range opts.IncludePatterns {
+		s.rawIncludes = append(s.rawIncludes, includeLiteral(pattern))
 		negatePattern := pattern
 		if !strings.HasPrefix(pattern, "!") {
 			negatePattern = "!" + pattern
@@ -61,74 +70,15 @@ func NewScanner(opts SyncOptions) (*Scanner, error) {
 		s.includes = append(s.includes, gitignore.ParsePattern(negatePattern, nil))
 	}
 
-	// Load root .gitignore if requested
-	if opts.UseGitignore {
-		if err := s.loadGitignoreFromDir(opts.SourceDir); err != nil {
-			return nil, err
-		}
-	}
-
 	return s, nil
 }
 
-// loadGitignoreFromDir loads .gitignore patterns from a specific directory
-func (s *Scanner) loadGitignoreFromDir(dir string) error {
-	// Check if already cached
-	if _, exists := s.gitignoreCache[dir]; exists {
-		return nil
-	}
-
-	gitignorePath := filepath.Join(dir, ".gitignore")
-	var patterns []gitignore.Pattern
-
-	// #nosec G304 -- gitignorePath is constructed from scanned directory within project
-	file, err := os.Open(gitignorePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// No .gitignore file in this directory, that's okay
-			s.gitignoreCache[dir] = patterns
-			return nil
-		}
-		return fmt.Errorf("failed to open .gitignore: %w", err)
-	}
-	defer file.Close()
-
-	// Calculate relative path from source directory to this .gitignore directory
-	// This ensures patterns are scoped to their directory, not applied globally
-	relDir, err := filepath.Rel(s.opts.SourceDir, dir)
-	if err != nil {
-		return fmt.Errorf("failed to get relative path for .gitignore domain: %w", err)
-	}
-
-	// Convert to forward slashes and split into path components for domain
-	var domain []string
-	if relDir != "." {
-		domain = strings.Split(filepath.ToSlash(relDir), "/")
-	}
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		// Skip comments and empty lines
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		// Parse pattern with domain so it only applies relative to this directory
-		pattern := gitignore.ParsePattern(line, domain)
-		patterns = append(patterns, pattern)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("failed to parse .gitignore: %w", err)
-	}
-
-	// Add patterns to global excludes
-	s.excludes = append(s.excludes, patterns...)
-
-	// Cache for this directory
-	s.gitignoreCache[dir] = patterns
-
-	return nil
+// includeLiteral strips the leading "!" (negation) and "/" (anchor) from an
+// include pattern, leaving the path used for ancestor-directory descent checks.
+func includeLiteral(pattern string) string {
+	pattern = strings.TrimPrefix(pattern, "!")
+	pattern = strings.TrimPrefix(pattern, "/")
+	return pattern
 }
 
 // Scan scans the source directory and returns a list of files to sync
@@ -145,13 +95,6 @@ func (s *Scanner) Scan() ([]FileInfo, error) {
 			return nil
 		}
 
-		// When entering a directory, check for .gitignore and load it
-		if info.IsDir() && s.opts.UseGitignore {
-			if err := s.loadGitignoreFromDir(path); err != nil {
-				return fmt.Errorf("failed to load .gitignore from %s: %w", path, err)
-			}
-		}
-
 		// Get relative path
 		relPath, err := filepath.Rel(s.opts.SourceDir, path)
 		if err != nil {
@@ -161,16 +104,18 @@ func (s *Scanner) Scan() ([]FileInfo, error) {
 		// Convert to forward slashes for pattern matching
 		relPath = filepath.ToSlash(relPath)
 
-		// Check if file should be included
-		if !s.shouldInclude(relPath, info.IsDir()) {
-			if info.IsDir() {
+		// Directories are never transferred themselves; we only decide whether to
+		// walk into them. Descend only when the directory could contain an included
+		// file, so a broad allowlist still prunes junk (e.g. node_modules/).
+		if info.IsDir() {
+			if !s.descendInto(relPath) {
 				return filepath.SkipDir
 			}
 			return nil
 		}
 
-		// Skip directories in the file list (we only transfer files)
-		if info.IsDir() {
+		// Deny-by-default: a file is synced only when the allowlist includes it.
+		if !s.shouldInclude(relPath, false) {
 			return nil
 		}
 
@@ -208,34 +153,94 @@ func (s *Scanner) Scan() ([]FileInfo, error) {
 	return files, nil
 }
 
-// shouldInclude determines if a file should be included based on patterns
+// shouldInclude determines whether a path should be synced. Selection is
+// deny-by-default:
+//
+//  1. Carve-outs (exclude patterns) win — if the path is excluded, it never ships.
+//  2. Otherwise the path ships only when the allowlist (include patterns) matches.
+//  3. Anything else is denied.
 func (s *Scanner) shouldInclude(relPath string, isDir bool) bool {
 	pathParts := strings.Split(relPath, "/")
 
-	// Last matching rule wins (standard gitignore semantics)
+	// Carve-outs always win over includes.
+	if s.isExcluded(pathParts, isDir) {
+		return false
+	}
+
+	// Allowlist: ship only when an include pattern matches.
+	for _, pattern := range s.includes {
+		if pattern.Match(pathParts, isDir) == gitignore.Include {
+			return true
+		}
+	}
+
+	// Deny by default.
+	return false
+}
+
+// isExcluded reports whether the path matches a carve-out pattern, using
+// gitignore last-match-wins semantics (a later "!" negation can re-include).
+func (s *Scanner) isExcluded(pathParts []string, isDir bool) bool {
 	excluded := false
 	for _, pattern := range s.excludes {
-		result := pattern.Match(pathParts, isDir)
-		switch result {
+		switch pattern.Match(pathParts, isDir) {
 		case gitignore.Exclude:
 			excluded = true
 		case gitignore.Include:
 			excluded = false
 		}
 	}
+	return excluded
+}
 
-	// Config-level include patterns act as a final override
-	if excluded {
-		for _, pattern := range s.includes {
-			result := pattern.Match(pathParts, isDir)
-			if result == gitignore.Include {
-				return true
-			}
-		}
+// descendInto reports whether the walk should enter a directory. It descends
+// when the directory could contain an included file, so a carved-out directory
+// (e.g. node_modules/) is pruned while ancestors of an include target are not.
+func (s *Scanner) descendInto(dirRelPath string) bool {
+	pathParts := strings.Split(dirRelPath, "/")
+
+	// Carve-outs prune the whole subtree.
+	if s.isExcluded(pathParts, true) {
 		return false
 	}
 
-	// Not excluded - include by default
+	// The directory itself is directly included (e.g. include "public/").
+	for _, pattern := range s.includes {
+		if pattern.Match(pathParts, true) == gitignore.Include {
+			return true
+		}
+	}
+
+	// The directory is an ancestor of an include target. A single-segment include
+	// (bare name like "vendor" or "public/") can match at any depth, so we must
+	// descend everywhere; a multi-segment include ("public/index.php") only
+	// requires descending into its literal parent directories.
+	for _, raw := range s.rawIncludes {
+		literal := strings.TrimSuffix(raw, "/")
+		if !strings.Contains(literal, "/") {
+			return true
+		}
+		if isSegmentPrefix(pathParts, raw) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isSegmentPrefix reports whether dirParts is a leading path-segment prefix of
+// the include pattern's literal path (e.g. ["public"] is a prefix of
+// "public/index.php", so we descend into "public").
+func isSegmentPrefix(dirParts []string, pattern string) bool {
+	patternParts := strings.Split(strings.TrimSuffix(pattern, "/"), "/")
+	if len(dirParts) >= len(patternParts) {
+		return false
+	}
+	for i, part := range dirParts {
+		if part != patternParts[i] {
+			return false
+		}
+	}
 	return true
 }
 

--- a/internal/rsync/sync_test.go
+++ b/internal/rsync/sync_test.go
@@ -1,17 +1,21 @@
 package rsync
 
 import (
+	"os"
+	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 )
 
 func makeScanner(excludePatterns, includePatterns []string) *Scanner {
-	s := &Scanner{gitignoreCache: make(map[string][]gitignore.Pattern)}
+	s := &Scanner{}
 	for _, p := range excludePatterns {
 		s.excludes = append(s.excludes, gitignore.ParsePattern(p, nil))
 	}
 	for _, p := range includePatterns {
+		s.rawIncludes = append(s.rawIncludes, includeLiteral(p))
 		neg := p
 		if len(p) == 0 || p[0] != '!' {
 			neg = "!" + p
@@ -21,6 +25,8 @@ func makeScanner(excludePatterns, includePatterns []string) *Scanner {
 	return s
 }
 
+// TestShouldInclude verifies the deny-by-default (allowlist) selection model:
+// a path ships only when an include matches and no carve-out excludes it.
 func TestShouldInclude(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -31,48 +37,58 @@ func TestShouldInclude(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:    "no patterns includes everything",
-			path:    "src/main.go",
-			want:    true,
+			name: "no patterns ships nothing (deny by default)",
+			path: "src/main.go",
+			want: false,
 		},
 		{
-			name:     "excluded file is skipped",
-			excludes: []string{"*.log"},
-			path:     "app.log",
+			name:     "included file ships",
+			includes: []string{"public/"},
+			path:     "public/index.php",
+			want:     true,
+		},
+		{
+			name:     "file outside allowlist is denied",
+			includes: []string{"public/"},
+			path:     "config/settings.php",
 			want:     false,
 		},
 		{
-			name:     "non-matching exclude keeps file",
-			excludes: []string{"*.log"},
-			path:     "src/main.go",
+			name:     "included directory ships its subtree at any depth",
+			includes: []string{"public/"},
+			path:     "public/css/theme/main.css",
 			want:     true,
 		},
 		{
-			name:     "negation after exclude re-includes file",
-			excludes: []string{"vendor", "!vendor/acme"},
-			path:     "vendor/acme",
-			isDir:    true,
+			name:     "bare-name include ships vendor without gitignore",
+			includes: []string{"vendor/"},
+			path:     "vendor/acme/lib.php",
 			want:     true,
 		},
 		{
-			name:     "later exclude overrides earlier negation",
-			excludes: []string{"!vendor/acme", "vendor"},
-			path:     "vendor/acme",
-			isDir:    true,
+			name:     "root file include ships",
+			includes: []string{"composer.json"},
+			path:     "composer.json",
+			want:     true,
+		},
+		{
+			name:     "carve-out wins over include",
+			includes: []string{"public/"},
+			excludes: []string{"public/typo3temp/"},
+			path:     "public/typo3temp/cache.php",
 			want:     false,
 		},
 		{
-			name:     "config include overrides exclude",
-			excludes: []string{"*.env"},
-			includes: []string{".env.example"},
-			path:     ".env.example",
-			want:     true,
+			name:     "junk-list carve-out wins over broad include",
+			includes: []string{"*"},
+			excludes: []string{"node_modules/"},
+			path:     "public/theme/node_modules/pkg/index.js",
+			want:     false,
 		},
 		{
-			name:     "config include does not affect non-excluded file",
-			excludes: []string{"*.log"},
-			includes: []string{"keep.txt"},
-			path:     "keep.txt",
+			name:     "wildcard include ships everything not carved out",
+			includes: []string{"*"},
+			path:     "some/deep/file.txt",
 			want:     true,
 		},
 	}
@@ -85,5 +101,135 @@ func TestShouldInclude(t *testing.T) {
 				t.Errorf("shouldInclude(%q, dir=%v) = %v, want %v", tc.path, tc.isDir, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestDescendInto verifies directory pruning: carved-out dirs are pruned, and
+// ancestors of an include target are descended into (the SkipDir footgun fix).
+func TestDescendInto(t *testing.T) {
+	tests := []struct {
+		name     string
+		excludes []string
+		includes []string
+		dir      string
+		want     bool
+	}{
+		{
+			name:     "descend into directly included dir",
+			includes: []string{"public/"},
+			dir:      "public",
+			want:     true,
+		},
+		{
+			name:     "descend into ancestor of anchored nested include",
+			includes: []string{"public/index.php"},
+			dir:      "public",
+			want:     true,
+		},
+		{
+			name:     "do not descend into unrelated dir for anchored include",
+			includes: []string{"public/index.php"},
+			dir:      "config",
+			want:     false,
+		},
+		{
+			name:     "prune carved-out dir even when included",
+			includes: []string{"*"},
+			excludes: []string{"node_modules/"},
+			dir:      "node_modules",
+			want:     false,
+		},
+		{
+			name: "no includes prunes everything",
+			dir:  "public",
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := makeScanner(tc.excludes, tc.includes)
+			if got := s.descendInto(tc.dir); got != tc.want {
+				t.Errorf("descendInto(%q) = %v, want %v", tc.dir, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestScanAllowlist is an end-to-end scan over a real temp tree. It proves the
+// SkipDir footgun is fixed: an anchored nested include (public/index.php) is
+// actually reached, and non-included paths are pruned.
+func TestScanAllowlist(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, root, "public/index.php", "a")
+	mustWrite(t, root, "public/css/main.css", "b")
+	mustWrite(t, root, "config/settings.php", "c")
+	mustWrite(t, root, "composer.json", "d")
+	mustWrite(t, root, ".git/HEAD", "e")
+	mustWrite(t, root, "node_modules/pkg/index.js", "f")
+
+	t.Run("nested file include is reached (footgun regression)", func(t *testing.T) {
+		got := scanRelPaths(t, root, []string{"node_modules/"}, []string{"public/index.php"})
+		want := []string{"public/index.php"}
+		assertPaths(t, got, want)
+	})
+
+	t.Run("directory allowlist ships subtree and prunes the rest", func(t *testing.T) {
+		got := scanRelPaths(t, root,
+			[]string{".git/", "node_modules/"},
+			[]string{"public/", "composer.json"},
+		)
+		want := []string{"composer.json", "public/css/main.css", "public/index.php"}
+		assertPaths(t, got, want)
+	})
+
+	t.Run("empty allowlist ships nothing", func(t *testing.T) {
+		got := scanRelPaths(t, root, nil, nil)
+		assertPaths(t, got, []string{})
+	})
+}
+
+func scanRelPaths(t *testing.T, root string, excludes, includes []string) []string {
+	t.Helper()
+	s, err := NewScanner(SyncOptions{
+		SourceDir:       root,
+		ExcludePatterns: excludes,
+		IncludePatterns: includes,
+	})
+	if err != nil {
+		t.Fatalf("NewScanner: %v", err)
+	}
+	files, err := s.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		paths = append(paths, f.RelPath)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func assertPaths(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("scanned %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("scanned %v, want %v", got, want)
+		}
+	}
+}
+
+func mustWrite(t *testing.T, root, rel, content string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
 	}
 }

--- a/internal/ui/output.go
+++ b/internal/ui/output.go
@@ -47,6 +47,12 @@ func (o *Output) Info(format string, args ...interface{}) {
 	o.Yellow.Printf(format+"\n", args...)
 }
 
+// Warning prints a warning message with an exclamation mark
+func (o *Output) Warning(format string, args ...interface{}) {
+	// #nosec G104 -- Printf errors in UI output can be safely ignored
+	o.Yellow.Printf("! "+format+"\n", args...)
+}
+
 // Step prints a step header with arrow
 func (o *Output) Step(format string, args ...interface{}) {
 	// #nosec G104 -- Printf errors in UI output can be safely ignored

--- a/tests/config-test/command-context.yaml
+++ b/tests/config-test/command-context.yaml
@@ -9,6 +9,11 @@ composer: composer.json
 rsync_src: ./
 keep_releases: 10
 
+# Deny-by-default allowlist: the commands below run `test -f composer.json` in
+# the release, so composer.json must be deployed.
+include:
+  - composer.json
+
 command_context: env
 
 hosts:

--- a/tests/config-test/lock-race.yaml
+++ b/tests/config-test/lock-race.yaml
@@ -4,6 +4,11 @@
 rsync_src: .
 keep_releases: 2
 
+# Deny-by-default allowlist (deploy a single small file; the test only cares
+# about lock contention, not the deployed contents).
+include:
+  - composer.json
+
 commands:
   - name: Hold the lock briefly
     run: sleep 2

--- a/tests/config-test/minimal.yaml
+++ b/tests/config-test/minimal.yaml
@@ -1,3 +1,7 @@
+# Deny-by-default allowlist: without an include nothing is deployed.
+include:
+  - public/
+  - composer.json
 hosts:
   production:
     hostname: 127.0.0.1
@@ -6,5 +10,5 @@ hosts:
     # optional but required for testing
     ssh_key: ../ssh_keys/shippy_key
     ssh_options:
-      StrictHostKeyChecking: yes # Not recommended for production use!
+      StrictHostKeyChecking: yes
     port: 2424

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -28,11 +28,17 @@ services:
       MYSQL_TCP_PORT: 3308
       MYSQL_ROOT_PASSWORD: db
     container_name: typo3-shippy-mariadb
+    # The database is throwaway and re-initialized on every `compose up`. Keeping
+    # the data dir on tmpfs makes first-boot init fast and immune to host disk
+    # contention, so the healthcheck below becomes healthy reliably even when the
+    # integration suite churns the stack up/down many times back-to-back.
+    tmpfs:
+      - /var/lib/mysql
     healthcheck:
       # Wait until MariaDB actually accepts connections before deploys run
       # `typo3 setup`, otherwise the install fails with "Connection refused".
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s
       timeout: 3s
-      retries: 12
-      start_period: 15s
+      retries: 20
+      start_period: 30s

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -89,6 +89,18 @@ teardown() {
   assert_output --partial "vendor/"
 }
 
+@test "Generated config uses a deny-by-default allowlist" {
+  run -0 ${BIN} init
+  assert_success
+
+  run cat .shippy.yaml
+  # Allowlist starter ships the essential TYPO3 paths
+  assert_output --partial "public/"
+  assert_output --partial "config/"
+  assert_output --partial "composer.json"
+  assert_output --partial "deny-by-default"
+}
+
 @test "Generated config should mark optional fields" {
   run -0 ${BIN} init
   assert_success

--- a/tests/typo3-v14/.shippy.yaml
+++ b/tests/typo3-v14/.shippy.yaml
@@ -1,8 +1,12 @@
+include:
+  - "public/"
+  - "vendor/"
+  - "config/"
+  - "composer.json"
+  - "composer.lock"
 exclude:
   - "**/*.rst"
   - "**/*.md"
-include:
-  - "public/.htaccess"
 shared:
   - .env
   - var/log/

--- a/tests/typo3/.shippy.yaml
+++ b/tests/typo3/.shippy.yaml
@@ -1,8 +1,12 @@
+include:
+  - "public/"
+  - "vendor/"
+  - "config/"
+  - "composer.json"
+  - "composer.lock"
 exclude:
   - "**/*.rst"
   - "**/*.md"
-include:
-  - "public/.htaccess"
 shared:
   - .env
   - var/log/


### PR DESCRIPTION
To make it more clear what is going
to be shipped to the remote a deny-by-default is used. So in case no "include" is given, nothing is
shipped to the remote server