### PR TITLE
Add per-command only/except host filters

### DIFF
--- a/.shippy.yaml.example
+++ b/.shippy.yaml.example
@@ -151,9 +151,19 @@ commands:
 
   - name: Database migrations
     run: ./vendor/bin/typo3 upgrade:run
+    # Only run this command for the listed host(s) (keys under `hosts:`).
+    # Skipped everywhere else. GitLab-CI-style; omit for "runs on every host".
+    only:
+      - production
 
   - name: Warmup caches
     run: ./vendor/bin/typo3 cache:warmup
+
+  # except is the inverse of only: runs everywhere except the listed hosts.
+  # - name: Notify host monitoring
+  #   run: /usr/local/bin/notify-deploy
+  #   except:
+  #     - staging
 
   # Per-command override: set an empty command_context to force a single command
   # to run on the host even when a global/per-host context is configured.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,45 @@ commands:
     run: <command to execute>
 ```
 
+### Commands
+
+`commands` (and `rollback_commands`) run in the new release directory, in order, before the atomic switchover. Each entry needs a `name` and a `run`:
+
+```yaml
+commands:
+  - name: Install dependencies
+    run: composer install --no-dev --optimize-autoloader
+
+  - name: Database migrations
+    run: ./vendor/bin/typo3 upgrade:run
+```
+
+**Scoping a command to specific hosts:**
+
+By default a command runs for every host in `hosts:`. Use `only` / `except` (GitLab-CI style) to scope a single command instead of duplicating the whole command list per host:
+
+```yaml
+commands:
+  - name: Database migrations
+    run: ./vendor/bin/typo3 upgrade:run
+    # Only run this command for the listed host(s) (keys under `hosts:`).
+    # Skipped everywhere else. Omit `only`/`except` entirely to run on every host.
+    only:
+      - production
+
+  - name: Notify monitoring
+    run: /usr/local/bin/notify-deploy
+    # except is the inverse of only: runs everywhere except the listed hosts.
+    except:
+      - staging
+```
+
+- `only` and `except` accept a list of host names (the keys under `hosts:`).
+- If a host matches both, `except` wins.
+- Commands skipped for a host are logged as skipped during `deploy`/`rollback`.
+- `shippy config validate` rejects `only`/`except` entries that reference a host name not defined under `hosts:`.
+- `shippy config show <host>` lists only the commands that actually apply to that host; `shippy config validate` annotates every command with its resolved scope.
+
 ### File Selection: Deny-by-Default (Allowlist)
 
 Shippy deploys files using an **allowlist**: by default **nothing is deployed**

--- a/README.md
+++ b/README.md
@@ -189,6 +189,38 @@ commands:
 - `shippy config validate` rejects `only`/`except` entries that reference a host name not defined under `hosts:`.
 - `shippy config show <host>` lists only the commands that actually apply to that host; `shippy config validate` annotates every command with its resolved scope.
 
+**Running commands inside a container (`command_context`):**
+
+If your PHP sources are mounted into a container, `command_context` runs every command inside a subcontext instead of directly on the remote host. When set, Shippy executes each command as:
+
+```
+<command_context> sh -c 'cd <release-dir> && <run>'
+```
+
+Shippy adds `sh -c` itself — give only the container-entry prefix, without a trailing shell (`docker exec php85`, not `docker exec php85 bash`). The `cd` happens *inside* the context, so the release directory must resolve to the same path there (the normal bind-mount case, e.g. `/var/www:/var/www`).
+
+`command_context` can be set globally, per host, or per command — the most specific one wins:
+
+```yaml
+# Global default for every host and command (optional; empty = run directly on the host)
+command_context: docker exec -u www-data php85
+
+hosts:
+  production:
+    hostname: example.com
+    remote_user: deploy
+    command_context: docker exec php84  # Overrides the global default for this host
+
+commands:
+  - name: Notify monitoring
+    run: /usr/local/bin/notify-deploy
+    # Per-command override. An empty string forces this command to run
+    # directly on the host even when a global/per-host context is set.
+    command_context: ""
+```
+
+Precedence: per-command > per-host (`hosts.<name>.command_context`) > global `command_context`.
+
 ### File Selection: Deny-by-Default (Allowlist)
 
 Shippy deploys files using an **allowlist**: by default **nothing is deployed**

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -135,7 +135,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	if len(cfg.Commands) > 0 {
 		fmt.Printf("Configured commands (%d):\n", len(cfg.Commands))
 		for i, cmd := range cfg.Commands {
-			fmt.Printf("  %d. %s\n", i+1, cmd.Name)
+			fmt.Printf("  %d. %s%s\n", i+1, cmd.Name, formatCommandScope(cmd))
 			fmt.Printf("     %s\n", cmd.Run)
 		}
 	}
@@ -143,7 +143,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	if len(cfg.RollbackCommands) > 0 {
 		fmt.Printf("Configured rollback commands (%d):\n", len(cfg.RollbackCommands))
 		for i, cmd := range cfg.RollbackCommands {
-			fmt.Printf("  %d. %s\n", i+1, cmd.Name)
+			fmt.Printf("  %d. %s%s\n", i+1, cmd.Name, formatCommandScope(cmd))
 			fmt.Printf("     %s\n", cmd.Run)
 		}
 	}
@@ -248,27 +248,51 @@ func buildResolvedHostConfig(cfg *config.Config, host *config.Host, hostName str
 		}
 	}
 
-	// Commands
+	// Commands (only those enabled for this host via only/except)
 	if len(cfg.Commands) > 0 {
 		sb.WriteString("\n# Commands\n")
 		sb.WriteString("commands:\n")
 		for _, cmd := range cfg.Commands {
+			if !cmd.AppliesToHost(hostName) {
+				sb.WriteString(fmt.Sprintf("  # - %s (skipped: not enabled for %s)\n", cmd.Name, hostName))
+				continue
+			}
 			sb.WriteString(fmt.Sprintf("  - name: %s\n", cmd.Name))
 			sb.WriteString(fmt.Sprintf("    run: %s\n", cmd.Run))
 		}
 	}
 
-	// Rollback commands
+	// Rollback commands (only those enabled for this host via only/except)
 	if len(cfg.RollbackCommands) > 0 {
 		sb.WriteString("\n# Rollback Commands\n")
 		sb.WriteString("rollback_commands:\n")
 		for _, cmd := range cfg.RollbackCommands {
+			if !cmd.AppliesToHost(hostName) {
+				sb.WriteString(fmt.Sprintf("  # - %s (skipped: not enabled for %s)\n", cmd.Name, hostName))
+				continue
+			}
 			sb.WriteString(fmt.Sprintf("  - name: %s\n", cmd.Name))
 			sb.WriteString(fmt.Sprintf("    run: %s\n", cmd.Run))
 		}
 	}
 
 	return sb.String()
+}
+
+// formatCommandScope renders a human-readable " (only: ...)" / " (except: ...)"
+// suffix for a command's host filters, or "" if unrestricted.
+func formatCommandScope(cmd config.Command) string {
+	var parts []string
+	if len(cmd.Only) > 0 {
+		parts = append(parts, fmt.Sprintf("only: %s", strings.Join(cmd.Only, ", ")))
+	}
+	if len(cmd.Except) > 0 {
+		parts = append(parts, fmt.Sprintf("except: %s", strings.Join(cmd.Except, ", ")))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (%s)", strings.Join(parts, "; "))
 }
 
 func formatStringSlice(slice []string) string {
@@ -280,4 +304,3 @@ func formatStringSlice(slice []string) string {
 	}
 	return fmt.Sprintf("[\"%s\"]", strings.Join(slice, "\", \""))
 }
-

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -207,18 +207,24 @@ func runRollback(cmd *cobra.Command, args []string) error {
 
 		executor := ssh.NewExecutor(client)
 
-		commands := make([]ssh.Command, len(cfg.RollbackCommands))
-		for i, cmd := range cfg.RollbackCommands {
-			commands[i] = ssh.Command{
+		var commands []ssh.Command
+		for _, cmd := range cfg.RollbackCommands {
+			if !cmd.AppliesToHost(hostName) {
+				out.Info("  Skipping %s (not enabled for %s)", cmd.Name, hostName)
+				continue
+			}
+			commands = append(commands, ssh.Command{
 				Name:    cmd.Name,
 				Run:     cmd.Run,
 				Context: cfg.GetCommandContext(host, cmd),
-			}
+			})
 		}
 
-		if err := executor.Execute(commands, selected.Path); err != nil {
-			out.Error("Rollback command execution failed: %v", err)
-			return err
+		if len(commands) > 0 {
+			if err := executor.Execute(commands, selected.Path); err != nil {
+				out.Error("Rollback command execution failed: %v", err)
+				return err
+			}
 		}
 	}
 

--- a/internal/config/command_scope_test.go
+++ b/internal/config/command_scope_test.go
@@ -1,0 +1,112 @@
+package config
+
+import "testing"
+
+func TestCommandAppliesToHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      Command
+		hostName string
+		want     bool
+	}{
+		{
+			name:     "no filters runs everywhere",
+			cmd:      Command{Run: "x"},
+			hostName: "production",
+			want:     true,
+		},
+		{
+			name:     "only matches listed host",
+			cmd:      Command{Run: "x", Only: []string{"production"}},
+			hostName: "production",
+			want:     true,
+		},
+		{
+			name:     "only skips unlisted host",
+			cmd:      Command{Run: "x", Only: []string{"production"}},
+			hostName: "staging",
+			want:     false,
+		},
+		{
+			name:     "except skips listed host",
+			cmd:      Command{Run: "x", Except: []string{"staging"}},
+			hostName: "staging",
+			want:     false,
+		},
+		{
+			name:     "except runs on unlisted host",
+			cmd:      Command{Run: "x", Except: []string{"staging"}},
+			hostName: "production",
+			want:     true,
+		},
+		{
+			name:     "except wins even if only would include",
+			cmd:      Command{Run: "x", Only: []string{"production"}, Except: []string{"production"}},
+			hostName: "production",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cmd.AppliesToHost(tt.hostName)
+			if got != tt.want {
+				t.Errorf("AppliesToHost(%q) = %v, want %v", tt.hostName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCommandHostRefs(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr bool
+	}{
+		{
+			name: "unknown host in only fails validation",
+			cfg: &Config{
+				Hosts: map[string]Host{
+					"production": {Hostname: "h", RemoteUser: "u", DeployPath: "/p"},
+				},
+				Commands: []Command{
+					{Name: "c", Run: "x", Only: []string{"staging"}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown host in except fails validation",
+			cfg: &Config{
+				Hosts: map[string]Host{
+					"production": {Hostname: "h", RemoteUser: "u", DeployPath: "/p"},
+				},
+				Commands: []Command{
+					{Name: "c", Run: "x", Except: []string{"staging"}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "known host in only passes validation",
+			cfg: &Config{
+				Hosts: map[string]Host{
+					"production": {Hostname: "h", RemoteUser: "u", DeployPath: "/p"},
+				},
+				Commands: []Command{
+					{Name: "c", Run: "x", Only: []string{"production"}},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -71,6 +72,26 @@ type Command struct {
 	// to run directly on the host even when a host/global context is set; nil
 	// means "inherit the host/global context".
 	CommandContext *string `yaml:"command_context,omitempty"`
+
+	// Only restricts this command to the listed host names (the keys under
+	// `hosts:`). Empty = runs on every host unless excluded below.
+	Only []string `yaml:"only,omitempty"`
+
+	// Except skips this command on the listed host names, even if Only would
+	// otherwise include it.
+	Except []string `yaml:"except,omitempty"`
+}
+
+// AppliesToHost reports whether the command should run when deploying to
+// hostName, per its only/except filters (GitLab CI style).
+func (cmd Command) AppliesToHost(hostName string) bool {
+	if len(cmd.Only) > 0 && !slices.Contains(cmd.Only, hostName) {
+		return false
+	}
+	if slices.Contains(cmd.Except, hostName) {
+		return false
+	}
+	return true
 }
 
 // Load reads and parses the configuration file
@@ -158,6 +179,9 @@ func (c *Config) Validate() error {
 				return err
 			}
 		}
+		if err := c.validateCommandHostRefs(cmd, fmt.Sprintf("commands[%d]", i)); err != nil {
+			return err
+		}
 	}
 	for i, cmd := range c.RollbackCommands {
 		if cmd.CommandContext != nil {
@@ -165,8 +189,27 @@ func (c *Config) Validate() error {
 				return err
 			}
 		}
+		if err := c.validateCommandHostRefs(cmd, fmt.Sprintf("rollback_commands[%d]", i)); err != nil {
+			return err
+		}
 	}
 
+	return nil
+}
+
+// validateCommandHostRefs checks that a command's only/except entries refer
+// to hosts actually defined in the config, catching typos at load time.
+func (c *Config) validateCommandHostRefs(cmd Command, field string) error {
+	for _, hostName := range cmd.Only {
+		if _, ok := c.Hosts[hostName]; !ok {
+			return fmt.Errorf("%s: only references unknown host '%s'", field, hostName)
+		}
+	}
+	for _, hostName := range cmd.Except {
+		if _, ok := c.Hosts[hostName]; !ok {
+			return fmt.Errorf("%s: except references unknown host '%s'", field, hostName)
+		}
+	}
 	return nil
 }
 

--- a/internal/deploy/deployer.go
+++ b/internal/deploy/deployer.go
@@ -184,20 +184,27 @@ func (d *Deployer) Deploy() error {
 
 		executor := ssh.NewExecutor(client)
 
-		// Convert config commands to SSH commands
-		commands := make([]ssh.Command, len(d.config.Commands))
-		for i, cmd := range d.config.Commands {
-			commands[i] = ssh.Command{
+		// Convert config commands to SSH commands, skipping any not enabled
+		// for this host via only/except.
+		var commands []ssh.Command
+		for _, cmd := range d.config.Commands {
+			if !cmd.AppliesToHost(d.hostName) {
+				out.Info("  Skipping %s (not enabled for %s)", cmd.Name, d.hostName)
+				continue
+			}
+			commands = append(commands, ssh.Command{
 				Name:    cmd.Name,
 				Run:     cmd.Run,
 				Context: d.config.GetCommandContext(d.host, cmd),
-			}
+			})
 		}
 
 		// Execute commands in the specific release directory (NOT the current symlink)
 		// This ensures commands run against the new release before it goes live
-		if err := executor.Execute(commands, releasePath); err != nil {
-			return fmt.Errorf("command execution failed: %w", err)
+		if len(commands) > 0 {
+			if err := executor.Execute(commands, releasePath); err != nil {
+				return fmt.Errorf("command execution failed: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Adds `only`/`except` fields to `commands`/`rollback_commands` entries, letting a single command be scoped to specific deploy targets (GitLab-CI style) instead of duplicating the whole command list per host.
- `Command.AppliesToHost(hostName)` resolves the filter (`except` wins over `only` when both match); skipped commands are logged during deploy/rollback.
- `Validate()` now rejects `only`/`except` entries that reference undefined hosts.
- `shippy config show <host>` shows only the commands that apply to that host; `shippy config validate` annotates each command with its scope.
- Documented in `.shippy.yaml.example`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New unit tests for `AppliesToHost` and the new validation in `internal/config/command_scope_test.go`