### PR TITLE
Add real SSH agent support alongside file-based key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,21 @@ hosts:
 
 **Important:** Always specify the **private key** (e.g., `id_ed25519`), not the public key (e.g., `id_ed25519.pub`).
 
+**SSH Agent:**
+
+If `ssh-agent` is running (`SSH_AUTH_SOCK` is set) or, on Windows, Pageant is running, Shippy also offers every key the agent holds — in addition to, not instead of, `ssh_key`. The server tries every offered key during authentication, so both sources are tried automatically; nothing needs to be configured to enable this.
+
+This matters most for passphrase-protected keys: Shippy cannot decrypt a passphrase-protected private key file itself, but if the same key is already loaded in your agent (`ssh-add`), it's used from there instead, and `ssh_key` can point at that same encrypted file without issue. With an agent running, `ssh_key` also becomes fully optional — no default key needs to exist on disk at all.
+
+```yaml
+hosts:
+  production:
+    hostname: example.com
+    remote_user: deploy
+    # No ssh_key needed - authenticates entirely via ssh-agent.
+    # Run `ssh-add ~/.ssh/id_ed25519` beforehand so the agent holds the key.
+```
+
 ### SSH Options
 
 You can configure SSH connection behavior using the `ssh_options` field. These options correspond to SSH configuration options (see `man ssh_config`):

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/soniakeys/quant v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xanzy/ssh-agent v0.3.3
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/image v0.41.0 // indirect
 	golang.org/x/net v0.56.0 // indirect

--- a/internal/ssh/agent_test.go
+++ b/internal/ssh/agent_test.go
@@ -1,0 +1,305 @@
+package ssh
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// startFakeAgent starts an in-process SSH agent (golang.org/x/crypto/ssh/agent.Keyring)
+// listening on a unix socket, points SSH_AUTH_SOCK at it for the duration of the test,
+// and returns the socket path. The listener and any accepted connections are cleaned
+// up via t.Cleanup.
+func startFakeAgent(t *testing.T, keys ...agent.AddedKey) string {
+	t.Helper()
+
+	keyring := agent.NewKeyring()
+	for _, k := range keys {
+		if err := keyring.Add(k); err != nil {
+			t.Fatalf("failed to add key to fake agent: %v", err)
+		}
+	}
+
+	// Use a short-lived dir outside t.TempDir(): the latter embeds the full
+	// (sub)test name, which regularly exceeds the ~104 byte sockaddr_un limit
+	// on macOS/BSD once nested subtests are involved.
+	sockDir, err := os.MkdirTemp("", "shippy-agent")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for agent socket: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+
+	sockPath := filepath.Join(sockDir, "a.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("failed to start fake ssh-agent listener: %v", err)
+	}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				_ = agent.ServeAgent(keyring, conn)
+				_ = conn.Close()
+			}()
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	t.Setenv("SSH_AUTH_SOCK", sockPath)
+	return sockPath
+}
+
+// generateEd25519Key returns a freshly generated ed25519 key pair.
+func generateEd25519Key(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ed25519 key: %v", err)
+	}
+	return priv
+}
+
+// writeUnencryptedKeyFile writes an unencrypted PEM-encoded private key to a file
+// under a fresh temp directory and returns its path.
+func writeUnencryptedKeyFile(t *testing.T, key ed25519.PrivateKey) string {
+	t.Helper()
+	block, err := ssh.MarshalPrivateKey(key, "test-key")
+	if err != nil {
+		t.Fatalf("failed to marshal private key: %v", err)
+	}
+	return writePEMKeyFile(t, block)
+}
+
+// writePassphraseProtectedKeyFile writes a passphrase-encrypted PEM-encoded private
+// key to a file under a fresh temp directory and returns its path.
+func writePassphraseProtectedKeyFile(t *testing.T, key ed25519.PrivateKey, passphrase string) string {
+	t.Helper()
+	block, err := ssh.MarshalPrivateKeyWithPassphrase(key, "test-key", []byte(passphrase))
+	if err != nil {
+		t.Fatalf("failed to marshal passphrase-protected private key: %v", err)
+	}
+	return writePEMKeyFile(t, block)
+}
+
+func writePEMKeyFile(t *testing.T, block *pem.Block) string {
+	t.Helper()
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_ed25519")
+	f, err := os.OpenFile(keyPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("failed to create key file: %v", err)
+	}
+	defer f.Close()
+	if err := pem.Encode(f, block); err != nil {
+		t.Fatalf("failed to write PEM key: %v", err)
+	}
+	return keyPath
+}
+
+// emptyHomeDir points $HOME at a fresh, key-less temp directory so default SSH key
+// discovery (~/.ssh/id_ed25519 etc.) reliably finds nothing, independent of the
+// machine actually running the test.
+func emptyHomeDir(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+// TestNewClientWithOptions_AgentOnly_NoKeyFileNeeded is also the regression test for
+// the exact bug reported against v0.0.9: with no ssh_key configured in .shippy.yaml
+// and no ~/.ssh/config entry, github.com/kevinburke/ssh_config.Get still returns its
+// own hardcoded "~/.ssh/identity" default for IdentityFile. That must never be
+// treated as if the user explicitly configured a key - if an agent is available, a
+// missing ~/.ssh/identity must not cause a hard failure.
+func TestNewClientWithOptions_AgentOnly_NoKeyFileNeeded(t *testing.T) {
+	emptyHomeDir(t)
+	startFakeAgent(t, agent.AddedKey{PrivateKey: generateEd25519Key(t)})
+
+	client, err := NewClientWithOptions(ClientOptions{
+		Host: "example.invalid",
+		Port: 22,
+		User: "deploy",
+	})
+	if err != nil {
+		t.Fatalf("expected agent-only auth to succeed without ssh_key, got error: %v", err)
+	}
+	defer client.Close()
+
+	if len(client.config.Auth) != 1 {
+		t.Fatalf("expected exactly 1 auth method (agent), got %d", len(client.config.Auth))
+	}
+	if client.agentConn == nil {
+		t.Fatal("expected agentConn to be set when ssh-agent is available")
+	}
+}
+
+func TestNewClientWithOptions_NoKeyNoAgent_Fails(t *testing.T) {
+	emptyHomeDir(t)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	_, err := NewClientWithOptions(ClientOptions{
+		Host: "example.invalid",
+		Port: 22,
+		User: "deploy",
+	})
+	if err == nil {
+		t.Fatal("expected error when neither ssh_key nor ssh-agent is available")
+	}
+	// Note: opts.KeyPath is empty here, but applySSHConfig() (via
+	// github.com/kevinburke/ssh_config) fills in its own hardcoded
+	// ~/.ssh/identity default in the absence of a real ~/.ssh/config entry, so
+	// this doesn't hit the "no default SSH key found in ~/.ssh/" message -
+	// it falls through to file-not-found -> no usable auth method at all.
+	if !strings.Contains(err.Error(), "no SSH authentication method available") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestNewClientWithOptions_PassphraseKeyWithAgent_SkipsFileKeyInsteadOfFailing(t *testing.T) {
+	emptyHomeDir(t)
+	startFakeAgent(t, agent.AddedKey{PrivateKey: generateEd25519Key(t)})
+
+	keyPath := writePassphraseProtectedKeyFile(t, generateEd25519Key(t), "correct horse battery staple")
+
+	client, err := NewClientWithOptions(ClientOptions{
+		Host:    "example.invalid",
+		Port:    22,
+		User:    "deploy",
+		KeyPath: keyPath,
+	})
+	if err != nil {
+		t.Fatalf("expected passphrase-protected key + available agent to succeed, got error: %v", err)
+	}
+	defer client.Close()
+
+	// Only the agent-backed auth method should have been added; the encrypted
+	// file key must be skipped rather than causing a hard failure.
+	if len(client.config.Auth) != 1 {
+		t.Fatalf("expected exactly 1 auth method (agent only, file key skipped), got %d", len(client.config.Auth))
+	}
+}
+
+func TestNewClientWithOptions_PassphraseKeyWithoutAgent_FailsWithHelpfulError(t *testing.T) {
+	emptyHomeDir(t)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	keyPath := writePassphraseProtectedKeyFile(t, generateEd25519Key(t), "correct horse battery staple")
+
+	_, err := NewClientWithOptions(ClientOptions{
+		Host:    "example.invalid",
+		Port:    22,
+		User:    "deploy",
+		KeyPath: keyPath,
+	})
+	if err == nil {
+		t.Fatal("expected error when key is passphrase-protected and no agent is available")
+	}
+	if !strings.Contains(err.Error(), "passphrase-protected") || !strings.Contains(err.Error(), "ssh-add") {
+		t.Fatalf("expected error to mention passphrase protection and ssh-add remedy, got: %v", err)
+	}
+}
+
+func TestNewClientWithOptions_ExplicitMissingKeyPath_FailsEvenWithAgent(t *testing.T) {
+	emptyHomeDir(t)
+	startFakeAgent(t, agent.AddedKey{PrivateKey: generateEd25519Key(t)})
+
+	_, err := NewClientWithOptions(ClientOptions{
+		Host:    "example.invalid",
+		Port:    22,
+		User:    "deploy",
+		KeyPath: filepath.Join(t.TempDir(), "does-not-exist"),
+	})
+	if err == nil {
+		t.Fatal("expected explicit but missing ssh_key to still be a hard error, even with an agent available")
+	}
+	if !strings.Contains(err.Error(), "SSH key not found") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestNewClientWithOptions_FileKeyAndAgent_BothOffered(t *testing.T) {
+	emptyHomeDir(t)
+	startFakeAgent(t, agent.AddedKey{PrivateKey: generateEd25519Key(t)})
+
+	keyPath := writeUnencryptedKeyFile(t, generateEd25519Key(t))
+
+	client, err := NewClientWithOptions(ClientOptions{
+		Host:    "example.invalid",
+		Port:    22,
+		User:    "deploy",
+		KeyPath: keyPath,
+	})
+	if err != nil {
+		t.Fatalf("expected success with both a valid file key and an agent, got error: %v", err)
+	}
+	defer client.Close()
+
+	if len(client.config.Auth) != 2 {
+		t.Fatalf("expected both agent and file key to be offered (2 auth methods), got %d", len(client.config.Auth))
+	}
+}
+
+func TestNewClientWithOptions_FileKeyOnly_NoAgent_StillWorks(t *testing.T) {
+	emptyHomeDir(t)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	keyPath := writeUnencryptedKeyFile(t, generateEd25519Key(t))
+
+	client, err := NewClientWithOptions(ClientOptions{
+		Host:    "example.invalid",
+		Port:    22,
+		User:    "deploy",
+		KeyPath: keyPath,
+	})
+	if err != nil {
+		t.Fatalf("expected unchanged pre-existing behavior (file key, no agent) to still work, got error: %v", err)
+	}
+	defer client.Close()
+
+	if len(client.config.Auth) != 1 {
+		t.Fatalf("expected exactly 1 auth method (file key), got %d", len(client.config.Auth))
+	}
+	if client.agentConn != nil {
+		t.Fatal("expected agentConn to be nil when no ssh-agent is available")
+	}
+}
+
+func TestClientClose_ClosesAgentConn(t *testing.T) {
+	emptyHomeDir(t)
+	startFakeAgent(t, agent.AddedKey{PrivateKey: generateEd25519Key(t)})
+
+	client, err := NewClientWithOptions(ClientOptions{
+		Host: "example.invalid",
+		Port: 22,
+		User: "deploy",
+	})
+	if err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	if client.agentConn == nil {
+		t.Fatal("expected agentConn to be set")
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("Close returned unexpected error: %v", err)
+	}
+	if client.agentConn != nil {
+		t.Fatal("expected agentConn to be cleared after Close")
+	}
+}

--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -10,9 +11,10 @@ import (
 	"strings"
 	"time"
 
+	sshagent "github.com/xanzy/ssh-agent"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/ochorocho/shippy/internal/errors"
+	shippyerrors "github.com/ochorocho/shippy/internal/errors"
 )
 
 // ClientOptions represents SSH client configuration options
@@ -30,17 +32,18 @@ type ClientOptions struct {
 
 // Client represents an SSH client connection
 type Client struct {
-	client             *ssh.Client
-	config             *ssh.ClientConfig
-	host               string
-	port               int
-	user               string
-	options            map[string]string
-	multiplexing       bool
-	proxyCommand       string
-	keepaliveInterval  time.Duration
-	keepaliveCountMax  int
-	keepaliveStopChan  chan struct{}
+	client            *ssh.Client
+	config            *ssh.ClientConfig
+	host              string
+	port              int
+	user              string
+	options           map[string]string
+	multiplexing      bool
+	proxyCommand      string
+	keepaliveInterval time.Duration
+	keepaliveCountMax int
+	keepaliveStopChan chan struct{}
+	agentConn         io.Closer
 }
 
 // NewClient creates a new SSH client
@@ -55,6 +58,14 @@ func NewClient(host, user, keyPath string) (*Client, error) {
 
 // NewClientWithOptions creates a new SSH client with full options
 func NewClientWithOptions(opts ClientOptions) (*Client, error) {
+	// Capture whether the caller (.shippy.yaml's ssh_key) actually set a key path,
+	// before applySSHConfig fills it in below. github.com/kevinburke/ssh_config
+	// returns its own hardcoded ~/.ssh/identity default for IdentityFile when
+	// ~/.ssh/config has no matching entry, so opts.KeyPath is otherwise always
+	// non-empty here - that default must not be treated as an explicit user choice,
+	// or a missing ~/.ssh/identity would hard-fail even with an agent available.
+	keyPathExplicit := opts.KeyPath != ""
+
 	// Extract ProxyCommand from ssh_options if set there (takes precedence over SSH config)
 	if opts.ProxyCommand == "" && opts.SSHOptions != nil {
 		opts.ProxyCommand = opts.SSHOptions["ProxyCommand"]
@@ -68,65 +79,114 @@ func NewClientWithOptions(opts ClientOptions) (*Client, error) {
 		opts.Port = DefaultSSHPort
 	}
 
-	// Determine SSH key path
+	var authMethods []ssh.AuthMethod
+	var agentConn io.Closer
+
+	// Offer keys held by a running ssh-agent (or Windows Pageant) first. The
+	// server tries every key from every AuthMethod during publickey auth, so
+	// this is purely additive alongside a file-based key below - it lets
+	// passphrase-protected or hardware-backed keys work without ever touching
+	// the private key material on disk.
+	if sshagent.Available() {
+		if agentClient, conn, err := sshagent.New(); err == nil {
+			authMethods = append(authMethods, ssh.PublicKeysCallback(agentClient.Signers))
+			agentConn = conn
+		}
+	}
+
+	// Determine SSH key path. An explicit ssh_key is only required when no
+	// agent is available to authenticate with instead.
 	keyPath := opts.KeyPath
 	if keyPath == "" {
 		// Try to find default SSH keys
 		home, err := getUserHomeDir()
-		if err != nil {
+		if err != nil && agentConn == nil {
 			return nil, fmt.Errorf("ssh_key not specified: %w", err)
 		}
 
-		// Try common SSH key locations
-		defaultKeys := []string{
-			filepath.Join(home, ".ssh", "id_ed25519"),
-			filepath.Join(home, ".ssh", "id_rsa"),
-			filepath.Join(home, ".ssh", "id_ecdsa"),
-		}
+		if err == nil {
+			// Try common SSH key locations
+			defaultKeys := []string{
+				filepath.Join(home, ".ssh", "id_ed25519"),
+				filepath.Join(home, ".ssh", "id_rsa"),
+				filepath.Join(home, ".ssh", "id_ecdsa"),
+			}
 
-		for _, defaultKey := range defaultKeys {
-			if _, err := os.Stat(defaultKey); err == nil {
-				keyPath = defaultKey
-				break
+			for _, defaultKey := range defaultKeys {
+				if _, err := os.Stat(defaultKey); err == nil {
+					keyPath = defaultKey
+					break
+				}
 			}
 		}
 
-		if keyPath == "" {
+		if keyPath == "" && agentConn == nil {
 			return nil, fmt.Errorf("ssh_key not specified in configuration and no default SSH key found in ~/.ssh/")
 		}
 	}
 
-	// Expand home directory if needed
-	var err error
-	keyPath, err = expandHomePath(keyPath)
-	if err != nil {
-		return nil, err
-	}
-
-	// Validate key path to prevent directory traversal
-	if err := validateSSHKeyPath(keyPath); err != nil {
-		return nil, fmt.Errorf("invalid SSH key path: %w", err)
-	}
-
-	// Check if key exists
-	if _, err := os.Stat(keyPath); err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("SSH key not found at '%s'. Please check your ssh_key configuration", keyPath)
+	if keyPath != "" {
+		// Expand home directory if needed
+		var err error
+		keyPath, err = expandHomePath(keyPath)
+		if err != nil {
+			return nil, err
 		}
-		return nil, fmt.Errorf("cannot access SSH key at '%s': %w", keyPath, err)
+
+		// Validate key path to prevent directory traversal
+		if err := validateSSHKeyPath(keyPath); err != nil {
+			return nil, fmt.Errorf("invalid SSH key path: %w", err)
+		}
+
+		// Check if key exists
+		if _, err := os.Stat(keyPath); err != nil {
+			if os.IsNotExist(err) {
+				if !keyPathExplicit {
+					// Default key lookup found nothing usable; fall back to agent-only auth.
+					keyPath = ""
+				} else {
+					return nil, fmt.Errorf("SSH key not found at '%s'. Please check your ssh_key configuration", keyPath)
+				}
+			} else {
+				return nil, fmt.Errorf("cannot access SSH key at '%s': %w", keyPath, err)
+			}
+		}
 	}
 
-	// Read private key
-	// #nosec G304 -- Path is validated above with validateSSHKeyPath
-	key, err := os.ReadFile(keyPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read SSH key from '%s': %w", keyPath, err)
+	if keyPath != "" {
+		// Read private key
+		// #nosec G304 -- Path is validated above with validateSSHKeyPath
+		key, err := os.ReadFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read SSH key from '%s': %w", keyPath, err)
+		}
+
+		// Parse private key
+		signer, err := ssh.ParsePrivateKey(key)
+		if err != nil {
+			var passphraseErr *ssh.PassphraseMissingError
+			if errors.As(err, &passphraseErr) && agentConn != nil {
+				// The key on disk is encrypted and we have no passphrase to unlock it,
+				// but ssh-agent is available and may already hold the decrypted key
+				// (e.g. via `ssh-add`). Skip the file-based auth method rather than
+				// failing hard - the agent-backed AuthMethod above still applies.
+				fmt.Fprintf(os.Stderr, "  • SSH key '%s' is passphrase-protected; relying on ssh-agent for it instead\n", keyPath)
+			} else if errors.As(err, &passphraseErr) {
+				return nil, fmt.Errorf("failed to parse SSH key from '%s': %w (key is passphrase-protected; unlock it via ssh-agent, e.g. `ssh-add %s`)", keyPath, err, keyPath)
+			} else {
+				return nil, fmt.Errorf("failed to parse SSH key from '%s': %w (make sure this is a private key, not a .pub file)", keyPath, err)
+			}
+			keyPath = ""
+		} else {
+			authMethods = append(authMethods, ssh.PublicKeys(signer))
+		}
 	}
 
-	// Parse private key
-	signer, err := ssh.ParsePrivateKey(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse SSH key from '%s': %w (make sure this is a private key, not a .pub file)", keyPath, err)
+	if len(authMethods) == 0 {
+		if agentConn != nil {
+			_ = agentConn.Close()
+		}
+		return nil, fmt.Errorf("no SSH authentication method available: no usable ssh_key and no ssh-agent running")
 	}
 
 	// Extract UserKnownHostsFile from ssh_options if specified
@@ -142,19 +202,25 @@ func NewClientWithOptions(opts ClientOptions) (*Client, error) {
 	if opts.ProxyCommand != "" {
 		fmt.Fprintf(os.Stderr, "  • ProxyCommand: %s\n", opts.ProxyCommand)
 	}
-	fmt.Fprintf(os.Stderr, "  • SSH key: %s\n", keyPath)
+	if keyPath != "" {
+		fmt.Fprintf(os.Stderr, "  • SSH key: %s\n", keyPath)
+	}
+	if agentConn != nil {
+		fmt.Fprintf(os.Stderr, "  • SSH agent: available\n")
+	}
 
 	// Create host key callback with proper verification
 	hostKeyCallback, err := createHostKeyCallback(&opts)
 	if err != nil {
+		if agentConn != nil {
+			_ = agentConn.Close()
+		}
 		return nil, fmt.Errorf("failed to create host key verification: %w", err)
 	}
 
 	config := &ssh.ClientConfig{
-		User: opts.User,
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(signer),
-		},
+		User:            opts.User,
+		Auth:            authMethods,
 		HostKeyCallback: hostKeyCallback,
 	}
 
@@ -164,6 +230,9 @@ func NewClientWithOptions(opts ClientOptions) (*Client, error) {
 	if timeoutStr, ok := opts.SSHOptions["ConnectTimeout"]; ok {
 		timeout, err := parseTimeout(timeoutStr)
 		if err != nil {
+			if agentConn != nil {
+				_ = agentConn.Close()
+			}
 			return nil, fmt.Errorf("invalid ConnectTimeout value '%s': %w", timeoutStr, err)
 		}
 		config.Timeout = timeout
@@ -177,6 +246,9 @@ func NewClientWithOptions(opts ClientOptions) (*Client, error) {
 	if intervalStr, ok := opts.SSHOptions["ServerAliveInterval"]; ok {
 		interval, err := parseTimeout(intervalStr)
 		if err != nil {
+			if agentConn != nil {
+				_ = agentConn.Close()
+			}
 			return nil, fmt.Errorf("invalid ServerAliveInterval value '%s': %w", intervalStr, err)
 		}
 		keepaliveInterval = interval
@@ -209,6 +281,7 @@ func NewClientWithOptions(opts ClientOptions) (*Client, error) {
 		proxyCommand:      opts.ProxyCommand,
 		keepaliveInterval: keepaliveInterval,
 		keepaliveCountMax: keepaliveCountMax,
+		agentConn:         agentConn,
 	}, nil
 }
 
@@ -225,19 +298,19 @@ func (c *Client) Connect() error {
 		// making the connection rather than the Go runtime's direct syscalls.
 		conn, err := dialProxy(c.proxyCommand, c.host, c.port)
 		if err != nil {
-			return errors.SSHError(fmt.Sprintf("connecting to %s@%s via ProxyCommand", c.user, addr), err)
+			return shippyerrors.SSHError(fmt.Sprintf("connecting to %s@%s via ProxyCommand", c.user, addr), err)
 		}
 		sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, c.config)
 		if err != nil {
 			_ = conn.Close()
-			return errors.SSHError(fmt.Sprintf("SSH handshake with %s@%s", c.user, addr), err)
+			return shippyerrors.SSHError(fmt.Sprintf("SSH handshake with %s@%s", c.user, addr), err)
 		}
 		client = ssh.NewClient(sshConn, chans, reqs)
 	} else {
 		var err error
 		client, err = ssh.Dial("tcp", addr, c.config)
 		if err != nil {
-			return errors.SSHError(fmt.Sprintf("connecting to %s@%s", c.user, addr), err)
+			return shippyerrors.SSHError(fmt.Sprintf("connecting to %s@%s", c.user, addr), err)
 		}
 	}
 
@@ -260,6 +333,11 @@ func (c *Client) Close() error {
 		c.keepaliveStopChan = nil
 	}
 
+	if c.agentConn != nil {
+		_ = c.agentConn.Close()
+		c.agentConn = nil
+	}
+
 	if c.client != nil {
 		return c.client.Close()
 	}
@@ -270,14 +348,14 @@ func (c *Client) Close() error {
 func (c *Client) RunCommand(cmd string) (string, error) {
 	session, err := c.client.NewSession()
 	if err != nil {
-		return "", errors.SSHError("creating SSH session", err)
+		return "", shippyerrors.SSHError("creating SSH session", err)
 	}
 	defer session.Close()
 
 	output, err := session.CombinedOutput(cmd)
 	if err != nil {
 		outputStr := strings.TrimSpace(string(output))
-		return outputStr, errors.CommandError(cmd, outputStr, err)
+		return outputStr, shippyerrors.CommandError(cmd, outputStr, err)
 	}
 
 	return string(output), nil


### PR DESCRIPTION
## Summary
- Offers keys from a running ssh-agent (or Windows Pageant via `xanzy/ssh-agent`, already a transitive dependency) additively alongside any file-based `ssh_key`, rather than as a sequential fallback — the SSH client already tries every key from every `AuthMethod` during publickey auth.
- Fixes a passphrase-protected `ssh_key` previously hard-failing with "passphrase protected" even when ssh-agent already held the decrypted key. The file-based key is now skipped in favor of the agent instead of aborting.
- `ssh_key` no longer needs to resolve to a real file when an agent is available — including papering over `github.com/kevinburke/ssh_config`'s own hardcoded `~/.ssh/identity` default when there's no `~/.ssh/config` entry (previously this silently forced a required-file check even when the user never configured `ssh_key`).

Real-world motivation: deploy targets whose `authorized_keys` are managed externally (e.g. via Puppet), where adding a dedicated unencrypted deploy key isn't practical — ssh-agent forwarding of an existing passphrase-protected key is the only viable path.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, including new `internal/ssh/agent_test.go`)
- [x] `go test ./internal/ssh/... -race` — new agent tests use a real in-process ssh-agent (golang.org/x/crypto/ssh/agent keyring served over a real unix socket) and real generated ed25519 keys (including an actually passphrase-encrypted one), asserting on the real `ssh.ClientConfig.Auth` — not mocked


🤖 Generated with [Claude Code](https://claude.com/claude-code)