### PR TITLE
Redact backup password in config show, fix Postgres DSN escaping

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -193,7 +193,7 @@ func showCompleteConfig(cfg *config.Config, out *ui.Output) error {
 	out.Header("Complete Configuration (with defaults applied)")
 	out.EmptyLine()
 
-	data, err := yaml.Marshal(cfg)
+	data, err := yaml.Marshal(cfg.Redacted())
 	if err != nil {
 		return fmt.Errorf("failed to generate YAML: %w", err)
 	}

--- a/internal/backup/postgres.go
+++ b/internal/backup/postgres.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -28,10 +29,21 @@ func NewPostgresDumper(client *ssh.Client, creds *DatabaseCredentials) (*Postgre
 
 	addr := fmt.Sprintf("%s:%d", creds.Host, port)
 
-	connConfig, err := pgx.ParseConfig(fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?sslmode=disable",
-		creds.User, creds.Password, creds.Host, port, creds.Name,
-	))
+	// Build the DSN via url.URL rather than Sprintf: creds.User/Password/Name
+	// can legitimately contain characters that are special in a "postgres://"
+	// URL (@, /, :, #, ?). url.UserPassword and the URL encoder percent-encode
+	// them so pgx.ParseConfig round-trips them correctly instead of silently
+	// mis-parsing the DSN (e.g. a password containing "@" splitting into the
+	// wrong host/database).
+	dsn := (&url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(creds.User, creds.Password),
+		Host:     addr,
+		Path:     "/" + creds.Name,
+		RawQuery: "sslmode=disable",
+	}).String()
+
+	connConfig, err := pgx.ParseConfig(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse PostgreSQL config: %w", err)
 	}

--- a/internal/config/backup.go
+++ b/internal/config/backup.go
@@ -25,6 +25,20 @@ type BackupDatabaseConfig struct {
 	Options       map[string]string `yaml:"options,omitempty"`        // DBMS-specific options
 }
 
+const redactedSecret = "***REDACTED***"
+
+// redacted returns a copy of the backup config with the database password
+// replaced with a placeholder, safe to print or log.
+func (b *BackupConfig) redacted() *BackupConfig {
+	redacted := *b
+	if redacted.Database != nil && redacted.Database.Password != "" {
+		db := *redacted.Database
+		db.Password = redactedSecret
+		redacted.Database = &db
+	}
+	return &redacted
+}
+
 // GetBackup returns backup config (per-host override or global default)
 func (c *Config) GetBackup(host *Host) *BackupConfig {
 	if host.Backup != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -375,6 +375,30 @@ func (c *Config) ApplyDefaults() {
 	}
 }
 
+// Redacted returns a copy of the config with secret values (e.g. backup
+// database passwords) replaced with a placeholder. Safe to print or log,
+// unlike marshalling the config directly.
+func (c *Config) Redacted() *Config {
+	redacted := *c
+
+	if redacted.Backup != nil {
+		redacted.Backup = redacted.Backup.redacted()
+	}
+
+	if redacted.Hosts != nil {
+		hosts := make(map[string]Host, len(redacted.Hosts))
+		for name, host := range redacted.Hosts {
+			if host.Backup != nil {
+				host.Backup = host.Backup.redacted()
+			}
+			hosts[name] = host
+		}
+		redacted.Hosts = hosts
+	}
+
+	return &redacted
+}
+
 // GetComposerPath returns the resolved composer.json path
 // Supports both relative (to config file) and absolute paths
 func (c *Config) GetComposerPath() string {


### PR DESCRIPTION
## Summary
- `shippy config show` (no host argument) marshalled the entire resolved `Config` struct to YAML, which included `backup.database.password` in plaintext. Added `Config.Redacted()` (and a `BackupConfig.redacted()` helper) to mask secret fields before display.
- The PostgreSQL backup DSN was built with `fmt.Sprintf` into a `postgres://` URL without percent-encoding the user/password. Credentials containing `@ / : ? #` were either silently mis-parsed (wrong host/database, truncated password, no error) or rejected outright by `pgx.ParseConfig`. Now built via `net/url.URL` + `url.UserPassword`, which round-trips these characters correctly.

Found during a full code/security review of the project; both were verified with reproductions (see PR discussion if needed) before fixing.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/config/... ./internal/backup/...`
- [x] Manually reproduced the `config show` leak before the fix and confirmed `password: '***REDACTED***'` after
- [x] Manually reproduced the Postgres DSN mis-parse against `pgx.ParseConfig` for passwords containing `@ / : ? #` before and after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)