### PR TITLE
Fix: statically link all release binaries with CGO_ENABLED=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,16 @@ help: ## Show this help message
 build: ## Build shippy binary with version info
 	@echo "Building shippy $(VERSION)..."
 	@mkdir -p dist
-	@go build -ldflags "$(LDFLAGS)" -o dist/shippy
+	@CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o dist/shippy
 	@echo "✓ Built dist/shippy"
 
 build-release: ## Build release binaries for all platforms
 	@echo "Building release binaries for version $(VERSION)..."
 	@mkdir -p dist
-	@GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/shippy-darwin-amd64
-	@GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/shippy-darwin-arm64
-	@GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/shippy-linux-amd64
-	@GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/shippy-linux-arm64
+	@CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/shippy-darwin-amd64
+	@CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/shippy-darwin-arm64
+	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/shippy-linux-amd64
+	@CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/shippy-linux-arm64
 	@echo "✓ Built all release binaries"
 	@ls -lh dist/
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ochorocho/shippy
 
 go 1.26
 
+toolchain go1.26.6
+
 require (
 	github.com/blacktop/go-termimg v0.1.26
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
## Summary
- `linux-amd64` release binaries were dynamically linked against glibc because CI builds natively for that arch (Go defaults `CGO_ENABLED=1`), while `linux-arm64` is cross-compiled and got a static binary as a side effect of Go's cross-compile default.
- Sets `CGO_ENABLED=0` explicitly on the `build` target (used by CI's per-arch matrix build, `.github/workflows/build.yml`) and on all four `go build` invocations in `build-release`, so every release asset is statically linked regardless of native vs. cross-compiled.
- shippy has no cgo dependencies, so this is a no-behavior-change fix.

Fixes #35

## Test plan
- [x] `GOOS=linux GOARCH=amd64 make build` then `file dist/shippy` confirms `statically linked` (previously `dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2`)
- [x] `go build ./...` and `go vet ./...` pass
- [ ] CI build/release workflow produces a `linux-amd64` asset that runs on Alpine without `gcompat`