### PR TITLE
Compare deploy cache by checksum instead of mtime

### DIFF
--- a/internal/rsync/transfer.go
+++ b/internal/rsync/transfer.go
@@ -1,6 +1,7 @@
 package rsync
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,10 @@ import (
 	"github.com/ochorocho/shippy/internal/ssh"
 	"github.com/ochorocho/shippy/internal/ui"
 )
+
+// cacheManifestFile maps relPath→sha256 of the cache contents. It lives outside
+// .cache/ so the rsync promote never copies it into a release.
+const cacheManifestFile = ".shippy/cache-manifest.json"
 
 // remoteClient is the subset of *ssh.Client the syncer needs. As an interface
 // it lets tests assert the exact remote commands (and their shell quoting)
@@ -73,13 +78,18 @@ func (s *Syncer) Sync(files []FileInfo) error {
 		localFiles[file.RelPath] = true
 	}
 
+	// Compared by checksum, not mtime: uploads don't preserve mtimes and CI
+	// checkouts restamp every file, which forced a full re-upload every deploy.
+	manifest := s.readCacheManifest()
+
 	out.Info("  Comparing local files with remote cache...")
 	for _, file := range files {
 		remoteInfo, exists := remoteFiles[file.RelPath]
 
 		needsUpload := !exists ||
 			remoteInfo.Size != file.Size ||
-			remoteInfo.Mtime < file.ModTime.Unix()
+			file.Checksum == "" ||
+			manifest[file.RelPath] != file.Checksum
 
 		if needsUpload {
 			filesToUpload = append(filesToUpload, file)
@@ -140,6 +150,11 @@ func (s *Syncer) Sync(files []FileInfo) error {
 		out.Success("Removed %d files from cache", deleted)
 	}
 
+	// Cache now matches the local tree; persist the manifest (best-effort).
+	if err := s.writeCacheManifest(files); err != nil {
+		out.Info("  Warning: could not write cache manifest (next deploy re-uploads everything): %v", err)
+	}
+
 	// Now copy from cache to release directory (rsync handles deletions)
 	fmt.Printf("\n")
 	out.Info("  Syncing cache to release directory (with deletions)...")
@@ -159,15 +174,14 @@ func (s *Syncer) Sync(files []FileInfo) error {
 
 // RemoteFileInfo holds remote file metadata
 type RemoteFileInfo struct {
-	Size  int64
-	Mtime int64
+	Size int64
 }
 
-// getRemoteFileIndex builds an index of all files in remote cache with their size/mtime
+// getRemoteFileIndex builds an index of all files in remote cache with their size
 func (s *Syncer) getRemoteFileIndex(cachePath string) (map[string]RemoteFileInfo, error) {
 	// Use find + stat to get all file info in one command
-	// Output format: path<tab>size<tab>mtime
-	cmd := fmt.Sprintf("cd %s && find . -type f -exec stat -c '%%n\t%%s\t%%Y' {} + 2>/dev/null || true", ssh.Quote(cachePath))
+	// Output format: path<tab>size
+	cmd := fmt.Sprintf("cd %s && find . -type f -exec stat -c '%%n\t%%s' {} + 2>/dev/null || true", ssh.Quote(cachePath))
 	output, err := s.client.RunCommand(cmd)
 	if err != nil {
 		return nil, err
@@ -183,26 +197,67 @@ func (s *Syncer) getRemoteFileIndex(cachePath string) (map[string]RemoteFileInfo
 		}
 
 		parts := strings.Split(line, "\t")
-		if len(parts) != 3 {
+		if len(parts) != 2 {
 			continue
 		}
 
 		// Remove leading "./" from path
 		path := strings.TrimPrefix(parts[0], "./")
 
-		var size, mtime int64
+		var size int64
 		// #nosec G104 -- Sscanf errors are acceptable here, defaults to 0
 		fmt.Sscanf(parts[1], "%d", &size)
-		// #nosec G104 -- Sscanf errors are acceptable here, defaults to 0
-		fmt.Sscanf(parts[2], "%d", &mtime)
 
-		index[path] = RemoteFileInfo{
-			Size:  size,
-			Mtime: mtime,
-		}
+		index[path] = RemoteFileInfo{Size: size}
 	}
 
 	return index, nil
+}
+
+func (s *Syncer) manifestPath() string {
+	return filepath.Join(s.deployPath, cacheManifestFile)
+}
+
+// readCacheManifest returns the stored checksums. Any failure yields an empty
+// map, which re-uploads everything.
+func (s *Syncer) readCacheManifest() map[string]string {
+	cmd := fmt.Sprintf("cat %s 2>/dev/null || true", ssh.Quote(s.manifestPath()))
+	output, err := s.client.RunCommand(cmd)
+	if err != nil {
+		return map[string]string{}
+	}
+
+	manifest := make(map[string]string)
+	if err := json.Unmarshal([]byte(output), &manifest); err != nil {
+		return map[string]string{}
+	}
+	return manifest
+}
+
+// writeCacheManifest uploads the checksum manifest for the synced files.
+func (s *Syncer) writeCacheManifest(files []FileInfo) error {
+	manifest := make(map[string]string, len(files))
+	for _, file := range files {
+		manifest[file.RelPath] = file.Checksum
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal cache manifest: %w", err)
+	}
+
+	tmp, err := os.CreateTemp("", "shippy-cache-manifest-*.json")
+	if err != nil {
+		return fmt.Errorf("failed to create temp manifest: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("failed to write temp manifest: %w", err)
+	}
+
+	return s.client.UploadFile(tmp.Name(), s.manifestPath(), 0o600)
 }
 
 // uploadWithProgress uploads files with progress reporting

--- a/internal/rsync/transfer_test.go
+++ b/internal/rsync/transfer_test.go
@@ -1,6 +1,8 @@
 package rsync
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -8,18 +10,20 @@ import (
 )
 
 type recordedUpload struct {
-	local  string
-	remote string
-	mode   os.FileMode
+	local   string
+	remote  string
+	mode    os.FileMode
+	content string // captured at call time; temp files are gone once Sync returns
 }
 
 // fakeClient records remote commands, mkdir calls and uploads. UploadFile does
 // not touch disk, so tests can use fabricated FileInfo entries.
 type fakeClient struct {
-	commands []string
-	mkdirs   []string
-	uploads  []recordedUpload
-	respond  func(cmd string) (string, error)
+	commands  []string
+	mkdirs    []string
+	uploads   []recordedUpload
+	respond   func(cmd string) (string, error)
+	uploadErr func(remotePath string) error
 }
 
 func (f *fakeClient) RunCommand(cmd string) (string, error) {
@@ -36,7 +40,16 @@ func (f *fakeClient) MkdirAll(path string) error {
 }
 
 func (f *fakeClient) UploadFile(localPath, remotePath string, mode os.FileMode) error {
-	f.uploads = append(f.uploads, recordedUpload{localPath, remotePath, mode})
+	if f.uploadErr != nil {
+		if err := f.uploadErr(remotePath); err != nil {
+			return err
+		}
+	}
+	content := ""
+	if data, err := os.ReadFile(localPath); err == nil {
+		content = string(data)
+	}
+	f.uploads = append(f.uploads, recordedUpload{localPath, remotePath, mode, content})
 	return nil
 }
 
@@ -56,7 +69,7 @@ func TestSyncQuotesRemoteCommands(t *testing.T) {
 	// so it must be deleted; the local file is new, so it must be uploaded.
 	f := &fakeClient{respond: func(cmd string) (string, error) {
 		if strings.Contains(cmd, "find . -type f") {
-			return "./old data.txt\t3\t100\n", nil
+			return "./old data.txt\t3\n", nil
 		}
 		return "", nil
 	}}
@@ -71,6 +84,7 @@ func TestSyncQuotesRemoteCommands(t *testing.T) {
 			Size:     5,
 			Mode:     0o644,
 			ModTime:  time.Unix(1000, 0),
+			Checksum: "sum-config",
 		},
 	}
 
@@ -91,9 +105,12 @@ func TestSyncQuotesRemoteCommands(t *testing.T) {
 		t.Errorf("expected cache dir %q created, mkdirs: %v", cache, f.mkdirs)
 	}
 
-	// Index scan, stale-file deletion, and final copy are all quoted.
+	// Index scan, manifest read, stale-file deletion, and final copy are all quoted.
 	if !f.saw("cd '/srv/my app/.cache' && find . -type f") {
 		t.Errorf("expected quoted find index command, commands: %v", f.commands)
+	}
+	if !f.saw("cat '/srv/my app/.shippy/cache-manifest.json'") {
+		t.Errorf("expected quoted manifest read command, commands: %v", f.commands)
 	}
 	if !f.saw("rm -f '/srv/my app/.cache/old data.txt'") {
 		t.Errorf("expected quoted deletion of stale cache file, commands: %v", f.commands)
@@ -102,25 +119,71 @@ func TestSyncQuotesRemoteCommands(t *testing.T) {
 		t.Errorf("expected quoted rsync copy, commands: %v", f.commands)
 	}
 
-	// The new local file is uploaded to its path under the cache.
-	if len(f.uploads) != 1 {
-		t.Fatalf("expected 1 upload, got %d: %v", len(f.uploads), f.uploads)
-	}
+	// The new local file is uploaded to its path under the cache, and the
+	// refreshed manifest is uploaded next to it.
 	wantRemote := cache + "/app/config.php"
-	if f.uploads[0].remote != wantRemote {
-		t.Errorf("upload remote = %q, want %q", f.uploads[0].remote, wantRemote)
+	fileUploaded := false
+	manifestUploaded := false
+	for _, u := range f.uploads {
+		if u.remote == wantRemote && u.local == "/local/app/config.php" {
+			fileUploaded = true
+		}
+		if u.remote == spacedDeploy+"/.shippy/cache-manifest.json" {
+			manifestUploaded = true
+		}
 	}
-	if f.uploads[0].local != "/local/app/config.php" {
-		t.Errorf("upload local = %q, want /local/app/config.php", f.uploads[0].local)
+	if !fileUploaded {
+		t.Errorf("expected upload of %q, uploads: %v", wantRemote, f.uploads)
+	}
+	if !manifestUploaded {
+		t.Errorf("expected manifest upload, uploads: %v", f.uploads)
 	}
 }
 
-func TestSyncSkipsUnchangedFiles(t *testing.T) {
-	// Remote cache already has the file with matching size and a newer mtime,
-	// so it should be skipped (no upload), and nothing should be deleted.
+// A fresh CI checkout restamps every file, so local mtimes are always newer
+// than the cache. Unchanged content must still be skipped.
+func TestSyncSkipsUnchangedFileWithNewerMtime(t *testing.T) {
 	f := &fakeClient{respond: func(cmd string) (string, error) {
 		if strings.Contains(cmd, "find . -type f") {
-			return "./app/config.php\t5\t2000\n", nil
+			return "./app/config.php\t5\n", nil
+		}
+		if strings.Contains(cmd, "cache-manifest.json") {
+			return `{"app/config.php":"abc123"}`, nil
+		}
+		return "", nil
+	}}
+
+	s := NewSyncer(f, spacedDeploy+"/releases/X", false, spacedDeploy)
+	files := []FileInfo{
+		{
+			RelPath:  "app/config.php",
+			FullPath: "/local/app/config.php",
+			Size:     5,
+			Mode:     0o644,
+			ModTime:  time.Unix(2000, 0), // newer than remote mtime 1000 (fresh checkout)
+			Checksum: "abc123",
+		},
+	}
+
+	if err := s.Sync(files); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	for _, u := range f.uploads {
+		if u.remote == spacedDeploy+"/.cache/app/config.php" {
+			t.Errorf("unchanged file was re-uploaded despite matching checksum: %v", f.uploads)
+		}
+	}
+}
+
+// Same size with an older local mtime (a composer downgrade restoring archive
+// mtimes) must still upload; the old mtime comparison shipped a stale file.
+func TestSyncUploadsWhenContentChangesButSizeMatches(t *testing.T) {
+	f := &fakeClient{respond: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "find . -type f") {
+			return "./app/config.php\t5\n", nil
+		}
+		if strings.Contains(cmd, "cache-manifest.json") {
+			return `{"app/config.php":"oldsum"}`, nil
 		}
 		return "", nil
 	}}
@@ -133,17 +196,161 @@ func TestSyncSkipsUnchangedFiles(t *testing.T) {
 			Size:     5,
 			Mode:     0o644,
 			ModTime:  time.Unix(1000, 0), // older than remote mtime 2000
+			Checksum: "newsum",
 		},
 	}
 
 	if err := s.Sync(files); err != nil {
 		t.Fatalf("Sync() error = %v", err)
 	}
-	if len(f.uploads) != 0 {
-		t.Errorf("expected no uploads for unchanged file, got %v", f.uploads)
+	uploaded := false
+	for _, u := range f.uploads {
+		if u.remote == spacedDeploy+"/.cache/app/config.php" {
+			uploaded = true
+		}
 	}
-	if f.saw("rm -f") {
-		t.Errorf("expected no deletions, commands: %v", f.commands)
+	if !uploaded {
+		t.Errorf("expected changed file to be uploaded, uploads: %v", f.uploads)
+	}
+}
+
+// The manifest drives the next deploy's skip decisions, so it must map every
+// synced file to its local checksum.
+func TestSyncWritesManifestWithLocalChecksums(t *testing.T) {
+	f := &fakeClient{}
+
+	s := NewSyncer(f, spacedDeploy+"/releases/X", false, spacedDeploy)
+	files := []FileInfo{
+		{RelPath: "a.php", FullPath: "/local/a.php", Size: 1, Mode: 0o644, ModTime: time.Unix(1000, 0), Checksum: "sum-a"},
+		{RelPath: "dir/b.php", FullPath: "/local/dir/b.php", Size: 2, Mode: 0o644, ModTime: time.Unix(1000, 0), Checksum: "sum-b"},
+	}
+
+	if err := s.Sync(files); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	var manifestJSON string
+	for _, u := range f.uploads {
+		if u.remote == spacedDeploy+"/.shippy/cache-manifest.json" {
+			manifestJSON = u.content
+		}
+	}
+	if manifestJSON == "" {
+		t.Fatalf("no manifest upload recorded, uploads: %v", f.uploads)
+	}
+
+	manifest := map[string]string{}
+	if err := json.Unmarshal([]byte(manifestJSON), &manifest); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v (content: %s)", err, manifestJSON)
+	}
+	want := map[string]string{"a.php": "sum-a", "dir/b.php": "sum-b"}
+	if len(manifest) != len(want) {
+		t.Errorf("manifest has %d entries, want %d: %v", len(manifest), len(want), manifest)
+	}
+	for relPath, checksum := range want {
+		if manifest[relPath] != checksum {
+			t.Errorf("manifest[%q] = %q, want %q", relPath, manifest[relPath], checksum)
+		}
+	}
+}
+
+// The manifest must only be written once every upload succeeded, otherwise it
+// vouches for files that never reached the cache and they are skipped forever.
+func TestSyncDoesNotWriteManifestWhenUploadFails(t *testing.T) {
+	f := &fakeClient{uploadErr: func(remotePath string) error {
+		if strings.HasSuffix(remotePath, "b.php") {
+			return fmt.Errorf("disk full")
+		}
+		return nil
+	}}
+
+	s := NewSyncer(f, spacedDeploy+"/releases/X", false, spacedDeploy)
+	files := []FileInfo{
+		{RelPath: "a.php", FullPath: "/local/a.php", Size: 1, Mode: 0o644, ModTime: time.Unix(1000, 0), Checksum: "sum-a"},
+		{RelPath: "b.php", FullPath: "/local/b.php", Size: 2, Mode: 0o644, ModTime: time.Unix(1000, 0), Checksum: "sum-b"},
+	}
+
+	if err := s.Sync(files); err == nil {
+		t.Fatal("Sync() returned nil, want error when an upload fails")
+	}
+	for _, u := range f.uploads {
+		if u.remote == spacedDeploy+"/.shippy/cache-manifest.json" {
+			t.Errorf("manifest written despite failed upload, uploads: %v", f.uploads)
+		}
+	}
+}
+
+// A file the manifest vouches for but that is gone from the cache must be
+// re-uploaded; the release is populated solely by rsync from the cache. Uses an
+// empty file, whose size matches the zero value a cache miss yields, so only
+// the presence check can catch it.
+func TestSyncUploadsWhenManifestMatchesButCacheFileMissing(t *testing.T) {
+	f := &fakeClient{respond: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "cache-manifest.json") {
+			return `{".gitkeep":"abc123"}`, nil
+		}
+		return "", nil
+	}}
+
+	s := NewSyncer(f, spacedDeploy+"/releases/X", false, spacedDeploy)
+	files := []FileInfo{
+		{
+			RelPath:  ".gitkeep",
+			FullPath: "/local/.gitkeep",
+			Size:     0,
+			Mode:     0o644,
+			ModTime:  time.Unix(1000, 0),
+			Checksum: "abc123",
+		},
+	}
+
+	if err := s.Sync(files); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	uploaded := false
+	for _, u := range f.uploads {
+		if u.remote == spacedDeploy+"/.cache/.gitkeep" {
+			uploaded = true
+		}
+	}
+	if !uploaded {
+		t.Errorf("expected re-upload of file missing from cache, uploads: %v", f.uploads)
+	}
+}
+
+// Without a manifest (first deploy after upgrade, or a corrupt file) nothing
+// can be trusted as cached, so everything is re-uploaded.
+func TestSyncUploadsAllWhenManifestMissing(t *testing.T) {
+	f := &fakeClient{respond: func(cmd string) (string, error) {
+		if strings.Contains(cmd, "find . -type f") {
+			return "./app/config.php\t5\n", nil
+		}
+		return "", nil
+	}}
+
+	s := NewSyncer(f, spacedDeploy+"/releases/X", false, spacedDeploy)
+	files := []FileInfo{
+		{
+			RelPath:  "app/config.php",
+			FullPath: "/local/app/config.php",
+			Size:     5,
+			Mode:     0o644,
+			ModTime:  time.Unix(500, 0),
+			Checksum: "abc123",
+		},
+	}
+
+	if err := s.Sync(files); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+	uploaded := false
+	for _, u := range f.uploads {
+		if u.remote == spacedDeploy+"/.cache/app/config.php" {
+			uploaded = true
+		}
+	}
+	if !uploaded {
+		t.Errorf("expected upload when manifest is missing, uploads: %v", f.uploads)
 	}
 }
 
@@ -164,7 +371,7 @@ func TestSyncCacheToReleaseFlags(t *testing.T) {
 
 	s := NewSyncer(f, spacedDeploy+"/releases/20240105120000", false, spacedDeploy)
 	files := []FileInfo{
-		{RelPath: "index.php", FullPath: "/local/index.php", Size: 1, Mode: 0o644, ModTime: time.Unix(1000, 0)},
+		{RelPath: "index.php", FullPath: "/local/index.php", Size: 1, Mode: 0o644, ModTime: time.Unix(1000, 0), Checksum: "sum-index"},
 	}
 	if err := s.Sync(files); err != nil {
 		t.Fatalf("Sync() error = %v", err)
@@ -197,7 +404,7 @@ func TestSyncCacheToReleaseFlags(t *testing.T) {
 
 func TestGetRemoteFileIndexParses(t *testing.T) {
 	f := &fakeClient{respond: func(string) (string, error) {
-		return "./a.txt\t10\t111\n./dir/b bin\t20\t222\n", nil
+		return "./a.txt\t10\n./dir/b bin\t20\n", nil
 	}}
 	s := NewSyncer(f, "/release", false, spacedDeploy)
 
@@ -208,10 +415,10 @@ func TestGetRemoteFileIndexParses(t *testing.T) {
 	if len(idx) != 2 {
 		t.Fatalf("got %d entries, want 2: %v", len(idx), idx)
 	}
-	if idx["a.txt"].Size != 10 || idx["a.txt"].Mtime != 111 {
+	if idx["a.txt"].Size != 10 {
 		t.Errorf("a.txt = %+v", idx["a.txt"])
 	}
-	if idx["dir/b bin"].Size != 20 || idx["dir/b bin"].Mtime != 222 {
+	if idx["dir/b bin"].Size != 20 {
 		t.Errorf("dir/b bin = %+v", idx["dir/b bin"])
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #34.

- Decide re-uploads by SHA256 instead of mtime. `Scanner.Scan()` already computed `FileInfo.Checksum` for every file but nothing read it; it is now compared against a manifest at `<deploy_path>/.shippy/cache-manifest.json`.
- The manifest lives outside `.cache/` so the `rsync --delete` promote cannot copy it into a release, and it is written only after all uploads succeed — otherwise it would vouch for files that never arrived.
- A missing or unparseable manifest yields an empty map, so everything is re-uploaded. The failure direction is always "upload more", never "skip".
- Mtime is no longer used, so the remote `stat` drops from three columns to two.

## Test plan
- [x] `go test ./...` and `go test -race ./...`
- [x] `make audit` — `go vet` and `gosec` clean (`govulncheck` reports a pre-existing stdlib advisory, GO-2026-5856, also present on `main`)
- [x] `make test` — 95/95
- [x] `make test-integration` — 26/26 against the Docker container, including the v13 and v14 deploys, `command_context`, and lock contention
- [x] New tests in `internal/rsync/transfer_test.go`: unchanged file with a newer (CI-style) mtime is skipped; changed file with matching size and an older mtime is still uploaded; manifest content matches local checksums; manifest is not written when an upload fails; cache file missing while the manifest matches still uploads; missing manifest re-uploads everything
